### PR TITLE
Fix second-half pistol detection when a half ends with a long post-round

### DIFF
--- a/apps/app/src/viewer/ViewerControls.vue
+++ b/apps/app/src/viewer/ViewerControls.vue
@@ -100,12 +100,16 @@ const markers = computed(() => buildTimelineMarkers(props.round))
  */
 const sideSwaps = computed<Set<number>>(() => {
   const swaps = new Set<number>()
-  // Sample sides from a mid-round frame: sides are locked there, unlike the
-  // freeze start (e.g. round 1 begins during the FACEIT side pick, so its first
-  // frame can still hold the pre-pick sides).
+  // Sample sides from the middle of the live window [startTick, endTick]. The
+  // freeze start is unreliable (round 1 begins during the FACEIT side pick, so
+  // its first frame can still hold the pre-pick sides), and the frame-array
+  // middle breaks when a round has a long post-round: the last round of a half
+  // absorbs the halftime break (plus any tech pause), so its array middle lands
+  // in the break where players already hold their swapped, second-half sides.
   const sidesOf = (r: Round) => {
     const m = new Map<string, Side>()
-    const f = r.frames[Math.floor(r.frames.length / 2)]
+    const target = r.startTick + (r.endTick - r.startTick) / 2
+    const f = r.frames.find((f) => f.tick >= target) ?? r.frames[Math.floor(r.frames.length / 2)]
     for (const p of f?.players ?? []) m.set(p.steamId, p.side)
     return m
   }

--- a/apps/app/src/viewer/roundEconomy.ts
+++ b/apps/app/src/viewer/roundEconomy.ts
@@ -82,10 +82,18 @@ function hasKnifeRound(rounds: Round[]): boolean {
   return r0.frames.every((f) => f.players.every((p) => p.weapon === 'Faca' || p.weapon === ''))
 }
 
-/** Sides sampled from a mid-round frame (locked there, unlike the freeze start). */
+/**
+ * Sides sampled from the middle of the live window [startTick, endTick]. Sampling
+ * by frame-array index is wrong when a round has a long post-round: the last round
+ * of a half absorbs the halftime break (and any tech pause), so its array middle
+ * lands in the break where players already hold their swapped, second-half sides.
+ * The freeze start is also unreliable (sides may still be mid-pick), so we anchor
+ * to gameplay.
+ */
 function sidesOf(r: Round): Map<string, Side> {
   const m = new Map<string, Side>()
-  const f = r.frames[Math.floor(r.frames.length / 2)]
+  const target = r.startTick + (r.endTick - r.startTick) / 2
+  const f = r.frames.find((f) => f.tick >= target) ?? r.frames[Math.floor(r.frames.length / 2)]
   for (const p of f?.players ?? []) m.set(p.steamId, p.side)
   return m
 }


### PR DESCRIPTION
## Problem

On `betboom-vs-furia-m1-overpass` the second-half pistol round (round 13) could not be located in the viewer: it lost its pistol icon, the side-swap marker landed on the wrong round, and the Economy tab classified its buy type incorrectly.

## Root cause

`sidesOf` sampled each round's sides from the **middle of the frame array** (`r.frames[length / 2]`). The last round of a half absorbs the halftime break (plus any tech pause, common at majors) into its post-round, so its frame array is dominated by break frames. For round 12 that pushed the array middle ~10s past the round end, into the halftime, where players already hold their swapped, second-half sides.

Consequences:
- The side swap was detected on round 12 (last round of the first half) instead of round 13.
- `pistolRounds` only checks rounds in `halfStarts` (first real round + side swaps), so it tested round 12 (a full buy → rejected) and **never tested round 13** → no pistol icon.
- The Economy tab marked the pistol buy on the wrong round.

## Fix

Sample sides from the **middle of the live window** `[startTick, endTick]`, anchoring to actual gameplay instead of the array index. Applied to both copies of `sidesOf` (`roundEconomy.ts` and `ViewerControls.vue`).

Pure frontend change, no wasm rebuild required.

## Verification

Re-parsed the demo and replicated the viewer logic:

```
before:  side swap detected on round 12  (wrong)
after:   side swap detected on round 13  (correct)
         pistol rounds -> [1, 13]
```

`pnpm type-check` passes.

## Out of scope

This does not change the parser. The last round of a half still keeps the long halftime gap in its post-round (a separate, cosmetic timeline issue), and explicit pause/timeout detection from the demo game-rules is a possible follow-up.