### PR TITLE
Filter grenade rendering by floor in the 2D viewer

### DIFF
--- a/apps/app/src/viewer/ViewerMap.vue
+++ b/apps/app/src/viewer/ViewerMap.vue
@@ -182,6 +182,8 @@ function drawGrenade(
   t: number,
 ) {
   if (!ctx) return
+  // Multi-floor maps: only the floor where the grenade went off (effect + timer).
+  if (!zOnActiveLevel(ev.z)) return
   const { x, y } = w2s(ev.x, ev.y)
   const span = Math.max(0.001, ev.endT - ev.t)
   const k = clamp((t - ev.t) / span, 0, 1)
@@ -347,6 +349,7 @@ function drawScorch(
   ev: Extract<Round['events'][number], { type: 'grenade' }>,
 ) {
   if (!ctx) return
+  if (!zOnActiveLevel(ev.z)) return
   const { x, y } = w2s(ev.x, ev.y)
   // HE blast covers a smaller area than fire
   const R = unitsToScreen(ev.kind === 'he' ? 90 : 150)
@@ -779,6 +782,26 @@ function onActiveLevel(p: PlayerState) {
 function zOnActiveLevel(z: number | null | undefined) {
   const lvl = props.levelRange
   return !lvl || z == null || (z >= lvl.minZ && z < lvl.maxZ)
+}
+
+/** Detonation Z of a flight path (its points carry none): the nearest grenade
+ *  event of the same kind in the round. Null when there is no match, which the
+ *  level filter then treats as visible. */
+function grenadePathZ(path: Round['grenadePaths'][number]): number | null {
+  const evs = props.round?.events
+  const last = path.points[path.points.length - 1]
+  if (!evs || !last) return null
+  let best: number | null = null
+  let bestDist = Infinity
+  for (const e of evs) {
+    if (e.type !== 'grenade' || e.kind !== path.kind) continue
+    const d = Math.hypot(e.x - last.x, e.y - last.y)
+    if (d < bestDist) {
+      bestDist = d
+      best = e.z
+    }
+  }
+  return best
 }
 
 function drawPlayer(p: PlayerState, death: { x: number; y: number } | undefined) {
@@ -1392,8 +1415,10 @@ function draw() {
     if (ev.type === 'kill' && ev.t <= killCutoff) deaths.set(ev.victimSteamId, { x: ev.x, y: ev.y })
   }
 
-  // arcs of grenades in flight (under the detonations)
-  for (const path of props.round?.grenadePaths ?? []) drawGrenadePath(path, t)
+  // arcs of grenades in flight (under the detonations), active floor only
+  for (const path of props.round?.grenadePaths ?? []) {
+    if (zOnActiveLevel(grenadePathZ(path))) drawGrenadePath(path, t)
+  }
   for (const ev of props.round?.events ?? []) {
     if (ev.type !== 'grenade') continue
     if (t >= ev.t && t <= ev.endT) drawGrenade(ev, t)


### PR DESCRIPTION
## What
Follow-up to #15. On two-floor maps (Nuke) the 2D viewer still drew all
grenade rendering on every floor: the flight arcs, the detonation effects
(smoke, fire, HE, flash), their duration timer and the burn scorch. So a
smoke or molotov on the lower B site also showed on the upper floor view.

## Fix
- Detonation effects and the scorch carry a Z, so they are now gated by
  the active floor (`zOnActiveLevel`), the same helper players use.
- Flight points carry no Z, so each arc is matched to its detonation
  event (same kind, nearest impact) to derive its floor.
- Falls back to visible when the Z is unknown, so older replays keep
  working.

## Note on the C4 blink
The planted C4 (blink included) was already floor-filtered in #15. If it
still shows on the wrong floor, the replay was parsed with a cached older
wasm that emits no C4 Z; a hard refresh to pick up the new parser fixes
it. No code change needed there.

## Verification
Driven in a browser against the Nuke replay, round 4 (planted on lower B,
upper smoke active): the upper smoke shows only on Superior, the planted
C4 shows only on Inferior, and neither leaks to the other floor.