### PR TITLE
fix(heatmap): exclude freeze-time frames from the presence heatmap

### DIFF
--- a/apps/app/src/viewer/analysis/HeatmapView.vue
+++ b/apps/app/src/viewer/analysis/HeatmapView.vue
@@ -88,7 +88,10 @@ const rawPoints = computed<Pt[]>(() => {
       }
     } else {
       // Presence: every sample of every player. High volume, but binning is O(n).
+      // Skip freeze-time frames: players sit still in spawn during the buy period,
+      // which otherwise makes the CT/T bases dwarf every real position on the map.
       for (const f of round.frames) {
+        if (f.tick < round.startTick) continue
         for (const p of f.players) {
           if (!p.alive) continue
           out.push({ x: p.x, y: p.y, z: p.z, side: p.side, steamId: p.steamId })


### PR DESCRIPTION
## Problem

In the presence heatmap, the hottest spots are the CT and T bases (spawns) for
both sides. That is wrong: it hides real in-round positioning.

The presence source bins every player sample of every frame, including the
freeze / buy period. During freeze (~15-20s per round) all ten players stand
still in a tight spawn cluster, stacking thousands of samples on a couple of
points, so the bases dwarf everything else on the map.

## Change

Skip frames before `round.startTick` (the freeze period) when collecting
presence points. Only live-round presence is counted; the start of the live
round still records players leaving spawn (legitimate movement), just not the
"standing still in spawn" part.

## Validation

Measured on a real demo by binning presence into a 100-unit grid:

- **Before:** freeze frames were 24% of all samples; the hottest cell was a
  spawn cell at 5.0% of all points, and the top 4 cells were the same spawn
  cluster.
- **After:** peak bin density dropped to 1.2%, spread across actual play
  positions; the spawn cells left the top entirely.

Filtering by freeze time is map-agnostic, which is why it was chosen over
hardcoding spawn areas per map/side.

## Test plan

- [x] `pnpm type-check` passes.
- [ ] Open a replay, switch the heatmap to Presence, and confirm the CT/T bases
      are no longer the dominant hotspots (CT and T checked separately).