### PR TITLE
fix(sides): read round sides from live frames so the pistol round isn't inverted

### DIFF
--- a/apps/app/src/viewer/analysis/HeatmapView.vue
+++ b/apps/app/src/viewer/analysis/HeatmapView.vue
@@ -4,6 +4,7 @@ import type { Replay, Round, Side } from '@/viewer/domain/schema'
 import { MAP_CALIBRATION } from '@/viewer/domain/calibration'
 import { SIDE_COLOR } from '@/viewer/domain/colors'
 import HeatmapPlot from '@/viewer/analysis/HeatmapPlot.vue'
+import { roundSides } from '@/viewer/analysis/utilityStats'
 import UiIcon from '@/ui/UiIcon.vue'
 import { useI18n } from '@/i18n'
 
@@ -38,22 +39,13 @@ const SOURCE_META: Record<Source, { labelKey: string; identity: boolean }> = {
 // detonations do not carry the thrower, so the filter is ignored for them.
 const hasIdentity = computed(() => SOURCE_META[source.value].identity)
 
-/** A player side in that round (read from the first frame that contains them). */
-const sideCache = new Map<string, Side | null>()
+/** A player's side in that round, from the live frames (so the pistol round's
+ *  post-knife side swap doesn't invert CT/T; see `roundSides`). Cached per round. */
+const sideCache = new Map<number, Map<string, Side>>()
 function sideInRound(round: Round, roundIdx: number, steamId: string): Side | null {
-  const key = `${roundIdx}:${steamId}`
-  const hit = sideCache.get(key)
-  if (hit !== undefined) return hit
-  let side: Side | null = null
-  for (const f of round.frames) {
-    const p = f.players.find((pl) => pl.steamId === steamId)
-    if (p) {
-      side = p.side
-      break
-    }
-  }
-  sideCache.set(key, side)
-  return side
+  let sides = sideCache.get(roundIdx)
+  if (!sides) sideCache.set(roundIdx, (sides = roundSides(round)))
+  return sides.get(steamId) ?? null
 }
 
 interface Pt {

--- a/apps/app/src/viewer/analysis/utilityStats.ts
+++ b/apps/app/src/viewer/analysis/utilityStats.ts
@@ -15,9 +15,27 @@ export interface Team {
   players: TeamPlayer[]
 }
 
-/** First-seen side per steamId in a round (sides are stable within a round). */
+/**
+ * Each player's side in a round, read from the live frames (after `startTick`).
+ *
+ * Live frames matter at the pistol round: when the match opens with a knife
+ * round, the side pick happens *during* the pistol round's freeze time, so its
+ * first frames still carry the knife-round sides before the swap. Reading the
+ * first frame would invert CT/T there. Live frames always carry the real round
+ * sides. First occurrence wins, so a player who dies early still gets a side.
+ *
+ * A second pass over every frame fills any player who never appears live (e.g.
+ * disconnected during freeze), so they still get a side instead of rendering
+ * gray; live frames already won for everyone present, so this never re-inverts.
+ */
 export function roundSides(round: Round): Map<string, Side> {
   const m = new Map<string, Side>()
+  for (const f of round.frames) {
+    if (f.tick < round.startTick) continue
+    for (const p of f.players) {
+      if (!m.has(p.steamId)) m.set(p.steamId, p.side)
+    }
+  }
   for (const f of round.frames) {
     for (const p of f.players) {
       if (!m.has(p.steamId)) m.set(p.steamId, p.side)

--- a/apps/app/src/viewer/player/useReplay.ts
+++ b/apps/app/src/viewer/player/useReplay.ts
@@ -1,6 +1,7 @@
 import { computed, onUnmounted, ref, shallowRef } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 import type { PlayerMeta, PlayerState, Replay, Round, Side } from '@/viewer/domain/schema'
+import { roundSides } from '@/viewer/analysis/utilityStats'
 
 /** Playback speeds offered in the controls. */
 export const SPEEDS = [1, 2, 4, 8] as const
@@ -173,19 +174,12 @@ export function useReplay() {
     return map
   })
 
-  /** Each player's side in the current round (constant within the round). Built
-   * from the union of all frames (first occurrence wins), not just the first
-   * frame: a player who is absent from frame 0 (e.g. already dead at the round's
-   * freeze/post-round edge) would otherwise have no side and render gray. */
-  const sideById = computed(() => {
-    const map = new Map<string, Side>()
-    for (const f of round.value?.frames ?? []) {
-      for (const p of f.players) {
-        if (!map.has(p.steamId)) map.set(p.steamId, p.side)
-      }
-    }
-    return map
-  })
+  /** Each player's side in the current round (constant within the round). Read
+   * from the live frames so the pistol round's post-knife side swap doesn't
+   * invert CT/T (see `roundSides`). */
+  const sideById = computed(() =>
+    round.value ? roundSides(round.value) : new Map<string, Side>(),
+  )
 
   /**
    * Knife round: some servers (FACEIT, scrims) open with a knife-only round to


### PR DESCRIPTION
## Problem

Voice comms were inverted on the pistol round: CT players were routed/shown as T
and vice versa.

Root cause: when a match opens with a **knife round**, the winning team picks its
side, and that swap happens **during the pistol round's freeze time**. The app
derives a player's round side from the **first frame** of the round, which on the
pistol round still carries the knife-round side (before the swap). So CT/T came
out inverted for the whole pistol round. Normal rounds have no swap inside the
freeze, so only the pistol round was affected.

The same first-frame logic existed in three places, all inverted on the pistol
round:
- `useReplay.ts` `sideById` -> voice comms (CT/T routing, mic indicator, waveform)
- `HeatmapView.vue` `sideInRound` -> death heatmap side/color
- `utilityStats.ts` `roundSides` -> flash/utility stats (and the killfeed flash
  assist derivation)

## Change

Read sides from the **live frames** (`tick >= startTick`), where the real round
sides are stable, with a second pass over every frame so a player who never
appears live still gets a side (no gray rendering). Centralized in `roundSides`;
`sideById` and `sideInRound` now reuse it instead of each rolling their own.

## Validation

Parsed a knife-round demo and compared first-frame vs live-frame sides:

- **round 0 (knife):** unchanged.
- **round 1 (pistol):** all 10 players flip back to their correct sides
  (e.g. `T -> CT`, `CT -> T`).
- **round 2+:** unchanged.

## Test plan

- [x] `pnpm type-check` passes.
- [ ] Open a knife-round demo, play the pistol round, and confirm comms, mic
      indicators, and the death heatmap show the correct sides.