### PR TITLE
feat(skill): add major-result skill

### DIFF
--- a/.claude/skills/major-result/SKILL.md
+++ b/.claude/skills/major-result/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: major-result
+description: Add or update a major playoff result from an HLTV match. Given the HLTV match URL plus a folder of the extracted GOTV .dem files (one major match, one or more maps, some maps split into p1/p2 halves), it parses each map into a committed .cs2dv replay (merging split maps), then updates the scoreboard (scores + maps) for the right bracket slot in apps/app/src/pages/major/playoffs.ts. Use when the user wants to "add a major result", "process a major demo", "update the bracket/scoreboard" from an HLTV match, or pastes an hltv.org/matches/... URL with a downloaded demo.
+---
+
+# Add a major playoff result
+
+Takes an HLTV match (URL + its downloaded GOTV demo) and produces the committed
+`.cs2dv` replays plus the scoreboard update for the IEM major bracket.
+
+## What the user provides
+
+1. The **HLTV match URL** (e.g. `https://www.hltv.org/matches/2395000/...`). Used for
+   human reference and to confirm teams/score; HLTV is Cloudflare-protected, so do
+   NOT try to fetch it from here (curl and WebFetch both get a 403).
+2. A **folder with the extracted `.dem` files**. HLTV ships the demo as a `.rar`
+   that this environment cannot open (no unrar/7z), so the user extracts it first.
+   File names look like `falcons-vs-vitality-m1-anubis-p1.dem` — note that some
+   maps come in two halves (`-p1`, `-p2`) that must be merged into one replay.
+3. The **bracket slot id** from `playoffs.ts` (`qf1`..`qf4`, `sf1`, `sf2`, `final`).
+   If unsure, infer it: the two team names in the file (`<a>-vs-<b>`) match a
+   slot's `teamA`/`teamB` (or its `sourceA`/`sourceB` winners for a TBD slot).
+   Confirm with the user before writing.
+
+If any of these is missing, ask for it before running anything.
+
+## Steps
+
+### 1. Build the replays
+
+Run the orchestrator (from the repo root). It groups the `.dem` files by map,
+parses each (with `--max-old-space-size=8192`), merges split maps, writes the
+final `.cs2dv` files into `replays/<dir>/<slot>-<map>.cs2dv`, and prints a JSON
+summary.
+
+```bash
+node .claude/skills/major-result/build-replays.mjs <slot> <demDir>
+# e.g. node .claude/skills/major-result/build-replays.mjs qf4 ~/Downloads/falcons-vs-vitality
+```
+
+The replay dir defaults to `major-cologne-2026` (matches `REPLAY_DIR` in
+`playoffs.ts`). Override with `--dir=<name>` for a different major.
+
+Each map can take a while (large demos). The trailing `SUMMARY (JSON)` block on
+stdout is what you use next: `{ slot, replayDir, maps: [{ mapNum, map, replay,
+ctName, tName, scoreCt, scoreT, winnerName }] }`.
+
+### 2. Update the scoreboard in playoffs.ts
+
+Edit `apps/app/src/pages/major/playoffs.ts`, the `MATCHES` entry whose `id`
+equals the slot:
+
+- **`maps`**: replace with the summary's maps in `mapNum` order. Each entry is
+  `{ map: '<map>', replay: \`${REPLAY_DIR}/<slot>-<slug>.cs2dv\` }` — use the
+  `REPLAY_DIR` template literal already used by the other entries, not a raw
+  string.
+- **`scoreA` / `scoreB`**: count map wins per team. Map each map's `winnerName`
+  (a GOTV clan name, e.g. "Team Vitality", "FALCONS") to a `TEAMS` id by matching
+  against each team's `name`/`short` (case-insensitive, allow partial match).
+  `scoreA` = maps won by the slot's `teamA`, `scoreB` = maps won by `teamB`.
+- **`teamA` / `teamB`**: if the slot is still TBD (`null`), fill them from the
+  matched team ids (order them so `teamA` is the higher seed, matching how the
+  seeded quarterfinals are laid out). If already set, leave them.
+- Leave `id`, `round`, `label`, `bestOf`, `date` as they are (only adjust `date`
+  if the user gives a corrected one).
+
+Show the user the resulting score (e.g. "Falcons 2-1 Vitality") and the team
+mapping you inferred, and ask them to confirm before considering it done.
+
+### 3. Sanity check
+
+- `scoreA + scoreB` should equal the number of maps, and the higher score should
+  match the series winner.
+- Run `cd apps/app && pnpm type-check` to confirm `playoffs.ts` still compiles.
+- The `.cs2dv` files live under the repo-root `replays/` dir (served via GitHub
+  raw in prod), NOT under `public/`. Do not move them.
+
+## Notes
+
+- Map slug vs map id: the `.dem` carries a short slug (`dust2`); `playoffs.ts`
+  uses the full id (`de_dust2`). The script emits both — use `map` for the field
+  and the file name already embeds the slug.
+- Do NOT commit or push. Per the repo rules, code is reviewed first; only commit
+  when the user explicitly asks.
+- If a `.dem` file name doesn't match `-m<N>-<map>[-p<K>].dem`, the script warns
+  and skips it. Rename it to the expected pattern or pass a clean folder.

--- a/.claude/skills/major-result/build-replays.mjs
+++ b/.claude/skills/major-result/build-replays.mjs
@@ -1,0 +1,120 @@
+// Turns a folder of HLTV `.dem` files (one major match, one or more maps, some
+// maps split into p1/p2 halves) into the committed `.cs2dv` replays for a bracket
+// slot, then prints a JSON summary the skill uses to update the scoreboard in
+// `apps/app/src/pages/major/playoffs.ts`.
+//
+//   node .claude/skills/major-result/build-replays.mjs <slot> <demDir> [--dir=major-cologne-2026]
+//   e.g. node .claude/skills/major-result/build-replays.mjs qf4 ~/Downloads/falcons-vs-vitality
+//
+// It reuses the existing scripts (no parsing logic duplicated here):
+//   - apps/app/scripts/process-major-demo.mjs  (parse one .dem -> .cs2dv)
+//   - apps/app/scripts/merge-replay-parts.mjs  (concat p1+p2 -> one .cs2dv)
+// Large demos need heap headroom, so every parse runs with
+// --max-old-space-size=8192.
+import { readdirSync, mkdirSync, rmSync, existsSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(here, '../../..')
+const scriptsDir = resolve(repoRoot, 'apps/app/scripts')
+
+const argv = process.argv.slice(2)
+const flags = Object.fromEntries(
+  argv.filter((a) => a.startsWith('--')).map((a) => a.replace(/^--/, '').split('=')),
+)
+const [slot, demDirArg] = argv.filter((a) => !a.startsWith('--'))
+if (!slot || !demDirArg) {
+  console.error('usage: build-replays.mjs <slot> <demDir> [--dir=major-cologne-2026]')
+  console.error('  <slot>   bracket slot id from playoffs.ts (qf1, sf1, final, ...)')
+  console.error('  <demDir> folder with the extracted .dem files for this match')
+  process.exit(1)
+}
+const replayDir = flags.dir || 'major-cologne-2026'
+const demDir = resolve(process.cwd(), demDirArg)
+const outDir = resolve(repoRoot, 'replays', replayDir)
+mkdirSync(outDir, { recursive: true })
+
+// Group .dem files by map. HLTV names them like
+//   <a>-vs-<b>-m<N>-<map>[-p<K>].dem
+// Key on the map slug (its halves p1/p2 share it); m<N> only orders the maps.
+const DEM_RE = /-m(\d+)-([a-z0-9_]+?)(?:-p(\d+))?\.dem$/i
+const maps = new Map() // slug -> { mapNum, slug, parts: [{ part, path }] }
+for (const name of readdirSync(demDir)) {
+  if (!name.toLowerCase().endsWith('.dem')) continue
+  const m = name.match(DEM_RE)
+  if (!m) {
+    console.error(`! skipping unrecognized file name: ${name}`)
+    continue
+  }
+  const mapNum = Number(m[1])
+  const slug = m[2].toLowerCase().replace(/^de_/, '') // store short slug (dust2, anubis)
+  const part = m[3] ? Number(m[3]) : 1
+  if (!maps.has(slug)) maps.set(slug, { mapNum, slug, parts: [] })
+  const entry = maps.get(slug)
+  entry.mapNum = Math.min(entry.mapNum, mapNum) // halves can carry the same m<N>
+  entry.parts.push({ part, path: join(demDir, name) })
+}
+if (maps.size === 0) {
+  console.error(`no .dem files found in ${demDir}`)
+  process.exit(1)
+}
+
+const node = process.execPath
+const heap = ['--max-old-space-size=8192']
+function run(script, args) {
+  // Inherit stderr so parser progress is visible; capture stdout to scrape the score line.
+  return execFileSync(node, [...heap, resolve(scriptsDir, script), ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    maxBuffer: 64 * 1024 * 1024,
+  })
+}
+
+// Pulls "<ctName> <a>-<b> <tName>" out of either script's final log line.
+function parseScore(stdout) {
+  const m = stdout.match(/(?:score|final)=(.+?) (\d+)-(\d+) (.+?) \(/)
+  if (!m) return null
+  return { ctName: m[1].trim(), scoreCt: Number(m[2]), scoreT: Number(m[3]), tName: m[4].trim() }
+}
+
+const summary = []
+for (const { mapNum, slug, parts } of [...maps.values()].sort((a, b) => a.mapNum - b.mapNum)) {
+  parts.sort((a, b) => a.part - b.part)
+  const outName = `${slot}-${slug}.cs2dv`
+  const outPath = join(outDir, outName)
+  let score
+
+  if (parts.length === 1) {
+    console.error(`\n=== map ${mapNum} (${slug}): 1 part ===`)
+    score = parseScore(run('process-major-demo.mjs', [parts[0].path, outPath]))
+  } else {
+    console.error(`\n=== map ${mapNum} (${slug}): ${parts.length} parts, will merge ===`)
+    const tmpParts = []
+    for (const { part, path } of parts) {
+      const tmp = join(tmpdir(), `${slot}-${slug}-p${part}.cs2dv`)
+      run('process-major-demo.mjs', [path, tmp])
+      tmpParts.push(tmp)
+    }
+    score = parseScore(run('merge-replay-parts.mjs', [outPath, ...tmpParts]))
+    for (const t of tmpParts) if (existsSync(t)) rmSync(t)
+  }
+
+  const winnerName = score && (score.scoreCt > score.scoreT ? score.ctName : score.tName)
+  summary.push({
+    mapNum,
+    map: `de_${slug}`,
+    replay: `${replayDir}/${outName}`,
+    ...(score ?? {}),
+    winnerName: winnerName || null,
+  })
+}
+
+// Machine-readable block for the skill to update playoffs.ts. Team names come
+// straight from the demo (GOTV clan names); the skill maps them to TEAMS ids and
+// counts map wins into scoreA/scoreB.
+console.error('\n----- SUMMARY (JSON) -----')
+console.log(JSON.stringify({ slot, replayDir, maps: summary }, null, 2))


### PR DESCRIPTION
## What

Adds a `/major-result` skill that turns an HLTV major match into committed `.cs2dv` replays plus the scoreboard update for the IEM major bracket.

Given:
1. the HLTV match URL (reference),
2. a folder of the extracted GOTV `.dem` files, and
3. the bracket slot id (`qf1`..`final`),

it produces the replays and updates `apps/app/src/pages/major/playoffs.ts`.

## How

`build-replays.mjs` reuses the existing scripts (no parsing logic duplicated):

- groups the `.dem` files by map slug (`-m<N>-<map>[-p<K>].dem`),
- parses each map via `process-major-demo.mjs` with an 8 GB heap,
- merges split maps (`p1`/`p2`) through `merge-replay-parts.mjs`,
- writes `replays/<dir>/<slot>-<map>.cs2dv`,
- prints a JSON summary the skill uses to fill `maps[]` and `scoreA`/`scoreB`.

`SKILL.md` guides the scoreboard edit: mapping GOTV clan names to `TEAMS` ids, counting map wins, filling TBD slots, and running `pnpm type-check`.

## Note on the download step

Demo download stays manual on purpose: HLTV is Cloudflare-protected (both `curl` and `WebFetch` get a 403 from this environment) and there is no `unrar`/`7z` available to open the `.rar`. The user downloads + extracts the `.rar` in the browser and points the skill at the folder.

## Files
- `.claude/skills/major-result/SKILL.md`
- `.claude/skills/major-result/build-replays.mjs`