### PR TITLE
fix(about): move page to /project, drop back button, fix author name

### DIFF
--- a/apps/app/src/pages/AboutPage.vue
+++ b/apps/app/src/pages/AboutPage.vue
@@ -14,7 +14,9 @@ const AUTHOR_URL = 'https://zenojunior.com'
 // The author paragraph carries the name as a `{name}` placeholder so it can be
 // rendered as a link; split it into the text before and after the name.
 const authorParts = computed(() => {
-  const [before, after] = t('about.authorBody').split('{name}')
+  // Use a NUL sentinel so vue-i18n's own interpolation doesn't drop the
+  // placeholder before we split the body around the author name.
+  const [before, after] = t('about.authorBody', { name: '\0' }).split('\0')
   return { before, after: after ?? '' }
 })
 
@@ -62,14 +64,6 @@ const RELATED: { name: string; url: string; desc: string }[] = [
 <template>
   <div class="h-full overflow-y-auto bg-ink-950">
     <div class="mx-auto max-w-2xl px-5 py-10 sm:px-6 sm:py-14">
-      <RouterLink
-        to="/"
-        class="mb-8 inline-flex items-center gap-1.5 text-xs text-ink-400 transition-colors hover:text-ink-200"
-      >
-        <UiIcon name="arrow-left" class="h-3.5 w-3.5" />
-        <span class="font-medium">{{ t('about.back') }}</span>
-      </RouterLink>
-
       <h1 class="text-2xl font-semibold text-ink-50 sm:text-3xl">{{ t('about.title') }}</h1>
       <p class="mt-3 text-sm leading-relaxed text-ink-300 sm:text-base">{{ t('about.tagline') }}</p>
 

--- a/apps/app/src/router.ts
+++ b/apps/app/src/router.ts
@@ -5,7 +5,7 @@ import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 // segment selects a sub-view (`heatmaps` / `grenades`), the 2D replay otherwise.
 const routes: RouteRecordRaw[] = [
   {
-    path: '/about',
+    path: '/project',
     name: 'about',
     component: () => import('@/pages/AboutPage.vue'),
   },

--- a/apps/app/src/shell/PublicShell.vue
+++ b/apps/app/src/shell/PublicShell.vue
@@ -69,7 +69,7 @@ provide(appFullscreenKey, { isFullscreen, toggle })
 
       <div class="flex items-center gap-2 text-xs text-ink-400 sm:gap-3">
         <RouterLink
-          to="/about"
+          to="/project"
           :aria-label="t('shell.about')"
           class="flex cursor-pointer items-center gap-1.5 rounded-md border border-ink-700 bg-ink-900/60 px-2 py-1 text-ink-200 transition-colors hover:bg-ink-800"
         >


### PR DESCRIPTION
## What

- **Rename `/about` → `/project`**: updates the route in `router.ts` and the nav link in `PublicShell.vue`.
- **Remove the "Back to the analyzer" link** at the top of the page.
- **Fix the author name bug**: the name ("Zeno Junior") was rendering at the end of the paragraph instead of inline.

## Why the author bug happened

`t('about.authorBody').split('{name}')` was called without passing the `name` param. vue-i18n interpolates `{name}` itself, so with no value it replaced the placeholder with an empty string *before* the split ran. The split then found nothing, `before` held the whole sentence, and the author link got appended at the end.

The fix interpolates a NUL sentinel as `name` and splits on that, so the link lands exactly where the catalog places `{name}`: "Built by **Zeno Junior**, a developer from Brazil...".

## Test plan

- `pnpm type-check` passes.
- Visit `/project`: page loads, no back button, author name renders inline as a link.