### PR TITLE
fix(major): fill SF2 per-map scores and restore type-check

### DIFF
--- a/apps/app/src/pages/major/playoffs.ts
+++ b/apps/app/src/pages/major/playoffs.ts
@@ -156,9 +156,9 @@ export const MATCHES: MajorMatch[] = [
     scoreA: 1,
     scoreB: 2,
     maps: [
-      { map: 'de_anubis', replay: `${REPLAY_DIR}/sf2-anubis.cs2dv` },
-      { map: 'de_mirage', replay: `${REPLAY_DIR}/sf2-mirage.cs2dv` },
-      { map: 'de_dust2', replay: `${REPLAY_DIR}/sf2-dust2.cs2dv` },
+      { map: 'de_anubis', replay: `${REPLAY_DIR}/sf2-anubis.cs2dv`, scoreA: 14, scoreB: 16 },
+      { map: 'de_mirage', replay: `${REPLAY_DIR}/sf2-mirage.cs2dv`, scoreA: 13, scoreB: 8 },
+      { map: 'de_dust2', replay: `${REPLAY_DIR}/sf2-dust2.cs2dv`, scoreA: 12, scoreB: 16 },
     ],
   },
   {


### PR DESCRIPTION
## What
The SF2 (Spirit vs Falcons) maps were added in #36 *before* the per-map score field landed in #37. Since `MajorMapReplay.scoreA/scoreB` are required, the three SF2 map entries had no score, which **broke the type-check** on `main` (and left the watch popover without per-map scores for SF2).

## Fix
Fill the SF2 maps with their final scores, taken from the committed replays' final score and cross-checked against Liquipedia:

| Map | Spirit | Falcons |
|-----|--------|---------|
| Anubis | 14 | 16 |
| Mirage | 13 | 8 |
| Dust2 | 12 | 16 |

Series: **Spirit 1-2 Falcons** (already correct). Now the per-map breakdown shows on the watch popover like the other matches.

## Testing
- `pnpm type-check` now passes (was failing on `main` with TS2739 on the three SF2 map entries).
- Scores verified against the parsed `sf2-*.cs2dv` replays and Liquipedia.