### PR TITLE
feat(extension): scope host permissions and bump to 1.0.2

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -76,4 +76,9 @@ and **offscreen.html** consoles.
 - Only `.dem.gz` and raw `.dem` are handled; `.zst` is not wired up yet.
 - Viewing a stored `.cs2dv` isn't built yet (Phase 2: a viewer inside the
   extension, reusing the app's components, so demos play without the site).
-- `host_permissions` is `<all_urls>`; tighten to the CDN hosts once known.
+- `host_permissions` is scoped to the shipping/next sources (`*.faceit.com`,
+  `*.faceit-cdn.net`, `*.hltv.org`, `*.gamersclub.com.br`); later sources
+  (`valve.net`, `5eplay.com`, `renown.gg`) are `optional_host_permissions`
+  requested at runtime (see `utils/permissions.ts`). A demo served from an
+  unlisted CDN host (e.g. HLTV's 302 redirect target) fails with a CORS error
+  until that host is added.

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cs2-demo-viewer-extension",
-  "version": "0.0.0",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "description": "CS Demo Analyzer: open any Faceit CS2 match as a 2D replay in one click, parsed locally and 100% offline.",

--- a/apps/extension/utils/permissions.ts
+++ b/apps/extension/utils/permissions.ts
@@ -1,0 +1,28 @@
+// Optional host-permission helpers, one per demo source. Faceit, HLTV and
+// GamersClub are required hosts; the rest are optional and granted at runtime.
+
+export type OptionalSource = 'valve' | '5eplay' | 'renown'
+
+const SOURCE_ORIGINS: Record<OptionalSource, string[]> = {
+  valve: ['*://*.valve.net/*'],
+  '5eplay': ['*://*.5eplay.com/*'],
+  renown: ['*://*.renown.gg/*'],
+}
+
+export function originsForSource(source: string): string[] {
+  return SOURCE_ORIGINS[source as OptionalSource] ?? []
+}
+
+export async function hasSourceHostPermissions(source: string): Promise<boolean> {
+  const origins = originsForSource(source)
+  if (origins.length === 0) return true
+  return chrome.permissions.contains({ origins })
+}
+
+// Must be called from an extension page inside a user gesture (not a content
+// script or the service worker), or chrome.permissions.request rejects.
+export async function requestSourceHostPermissions(source: string): Promise<boolean> {
+  const origins = originsForSource(source)
+  if (origins.length === 0) return true
+  return chrome.permissions.request({ origins })
+}

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -14,7 +14,15 @@ export default defineConfig({
     name: 'CS Demo Analyzer',
     description: 'Open any Faceit CS2 match as a 2D replay in one click. Demos are downloaded and parsed locally, 100% offline.',
     permissions: ['storage', 'offscreen'],
-    host_permissions: ['<all_urls>'],
+    // Required hosts: the shipping/next sources. Avoids <all_urls> and its review.
+    host_permissions: [
+      '*://*.faceit.com/*',
+      '*://*.faceit-cdn.net/*',
+      '*://*.hltv.org/*',
+      '*://*.gamersclub.com.br/*',
+    ],
+    // Later sources, granted at runtime via chrome.permissions.request.
+    optional_host_permissions: ['*://*.valve.net/*', '*://*.5eplay.com/*', '*://*.renown.gg/*'],
     // The offscreen document runs the WASM parser; allow wasm in extension pages.
     content_security_policy: {
       extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",


### PR DESCRIPTION
## What

Replaces the extension's `<all_urls>` host permission, which triggers the Chrome Web Store "broad host permission" detailed review, with per-source scoped hosts.

## Why

Submitting 1.0.x to the Web Store flagged a *Permissões amplas do host* warning ("possível revisão detalhada que atrasará a publicação"). The extension never needs all hosts: it only fetches from the demo platforms the user explicitly opens. Content-script injection is already granted by each script's own `matches`, so `host_permissions` only has to cover the cross-origin fetches (the overlay's API calls + the offscreen downloading the demo file).

## Changes

- **`host_permissions`** (required at install): `*.faceit.com`, `*.faceit-cdn.net` (shipping today) plus `*.hltv.org` and `*.gamersclub.com.br` (the next two sources to be implemented).
- **`optional_host_permissions`** (granted at runtime): `*.valve.net`, `*.5eplay.com`, `*.renown.gg` (later sources).
- **`utils/permissions.ts`**: source -> origins map + `hasSourceHostPermissions` / `requestSourceHostPermissions`. `chrome.permissions.request` only works from an extension page inside a user gesture (not a content script), documented on the request helper.
- **Version bump to 1.0.2** (`package.json` drives the WXT manifest version).
- **README**: limitations note updated to describe the scoped/optional host model.

## Follow-ups (not in this PR)

- HLTV: capture the real CDN host behind its `/download/demo/<id>` 302 redirect, and add a `.rar` extractor (the current pipeline only handles `.gz`/`.zst`/raw `.dem`).
- Optional-source flow: a small extension grant page + download gate to call `requestSourceHostPermissions` when Valve/5EPlay/Renown land.

## Testing

- `pnpm type-check` passes.
- `pnpm build` + `pnpm zip` produce `cs2-demo-viewer-extension-1.0.2-chrome.zip`; built manifest verified to carry the scoped `host_permissions` + `optional_host_permissions`.