### PR TITLE
perf(viewer): cache smoke/fire effects as offscreen sprites

### DIFF
--- a/apps/app/src/viewer/player/ViewerMap.vue
+++ b/apps/app/src/viewer/player/ViewerMap.vue
@@ -5,7 +5,6 @@ import { worldToFraction, worldFromFraction, DEFAULT_BLAST_RADIUS, type MapCalib
 import { SIDE_COLOR } from '@/viewer/domain/colors'
 import { commentPositionAt, isCommentActive } from '@/viewer/comments/commentAnchor'
 import { commentKindMeta } from '@/viewer/comments/commentKinds'
-import { WEAPON_LABELS, weaponIconPath } from '@/viewer/domain/weaponIcons'
 import {
   COACH_DEFAULT_COLOR,
   COACH_DEFAULT_THICKNESS,
@@ -16,6 +15,9 @@ import {
   type CoachTool,
 } from '@/viewer/player/coachTools'
 import type { GrenadeKind } from '@/viewer/domain/schema'
+import { createGrenadeEffects } from '@/viewer/player/grenadeEffects'
+import { clamp, drawKill, roundRect, wrapText } from '@/viewer/player/canvasUtils'
+import { useViewerAssets } from '@/viewer/player/useViewerAssets'
 import { useI18n } from '@/i18n'
 
 // `t` is used internally for time; i18n is aliased as `tr`.
@@ -129,32 +131,11 @@ let panY = 0
 const radar = new Image()
 let radarReady = false
 
-// Mic icon (talking indicator), preloaded per team color.
-function makeMic(color: string) {
-  const svg =
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><path d="M12 19v3"/></svg>`
-  const img = new Image()
-  img.src = `data:image/svg+xml,${encodeURIComponent(svg)}`
-  img.onload = () => draw()
-  return img
-}
-const micImgs: Record<Side, HTMLImageElement> = {
-  CT: makeMic(SIDE_COLOR.CT),
-  T: makeMic(SIDE_COLOR.T),
-}
+// Mic/weapon/comment icon assets, preloaded; redraw as each image loads.
+const { micImgs, weaponImgs, kindIconPaths } = useViewerAssets(() => draw())
 
-// weapon icons (SVG) preloaded as images to draw on the canvas
-const weaponImgs = new Map<string, HTMLImageElement>()
-for (const label of WEAPON_LABELS) {
-  const path = weaponIconPath(label)
-  if (!path) continue
-  const img = new Image()
-  img.src = path
-  img.onload = () => draw()
-  weaponImgs.set(label, img)
-}
-
-const clamp = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v))
+// Smoke/fire/scorch rendering + its offscreen sprite cache (see grenadeEffects).
+const effects = createGrenadeEffects()
 
 function fit() {
   L = Math.min(cw, ch)
@@ -214,114 +195,6 @@ function playerPose(p: PlayerState): { x: number; y: number; yaw: number } {
   return coachPosOf(p) ?? { x: p.x, y: p.y, yaw: p.yaw }
 }
 
-function drawKill(x: number, y: number, alpha: number) {
-  if (!ctx) return
-  const r = 7
-  ctx.save()
-  ctx.globalAlpha = alpha
-  ctx.strokeStyle = '#ff4d5e'
-  ctx.lineWidth = 2
-  ctx.beginPath()
-  ctx.moveTo(x - r, y - r)
-  ctx.lineTo(x + r, y + r)
-  ctx.moveTo(x + r, y - r)
-  ctx.lineTo(x - r, y + r)
-  ctx.stroke()
-  ctx.restore()
-}
-
-// Deterministic per-position noise, so an effect's shape is stable across frames.
-function effectRand(seed: number) {
-  return (n: number) => {
-    const v = Math.sin(n * 12.9898 + seed * 78.233) * 43758.5453
-    return v - Math.floor(v)
-  }
-}
-
-/** Paints a smoke cloud body (puffy irregular disc) centered at screen (x, y).
- *  Shared by live detonations and the coach board so they look identical. */
-function paintSmoke(x: number, y: number, R: number, t: number, seed: number) {
-  if (!ctx) return
-  const rand = effectRand(seed)
-  const verts = 34
-  const ring: { x: number; y: number }[] = []
-  for (let i = 0; i < verts; i++) {
-    const ang = (i / verts) * Math.PI * 2
-    const wob = 0.86 + 0.12 * rand(i + 7) + 0.03 * Math.sin(t * 1.8 + i * 0.5 + seed)
-    ring.push({ x: x + Math.cos(ang) * R * wob, y: y + Math.sin(ang) * R * wob })
-  }
-  const tracePath = () => {
-    ctx!.beginPath()
-    ctx!.moveTo(ring[0].x, ring[0].y)
-    for (let i = 1; i < ring.length; i++) ctx!.lineTo(ring[i].x, ring[i].y)
-    ctx!.closePath()
-  }
-  ctx.save()
-  ctx.filter = `blur(${clamp(R * 0.06, 2, 7)}px)`
-  const grad = ctx.createRadialGradient(x, y, R * 0.1, x, y, R)
-  grad.addColorStop(0, 'rgba(220, 224, 232, 0.46)')
-  grad.addColorStop(0.7, 'rgba(208, 213, 224, 0.34)')
-  grad.addColorStop(1, 'rgba(206, 211, 222, 0.04)')
-  ctx.fillStyle = grad
-  tracePath()
-  ctx.fill()
-  const puffs = 7
-  for (let i = 0; i < puffs; i++) {
-    const ang = rand(i + 50) * Math.PI * 2 + t * 0.12
-    const dist = R * (0.1 + 0.42 * rand(i + 80))
-    const px = x + Math.cos(ang) * dist
-    const py = y + Math.sin(ang) * dist
-    const pr = R * (0.28 + 0.22 * rand(i + 90))
-    const pg = ctx.createRadialGradient(px, py, 0, px, py, pr)
-    pg.addColorStop(0, 'rgba(230, 234, 242, 0.2)')
-    pg.addColorStop(1, 'rgba(220, 224, 232, 0)')
-    ctx.fillStyle = pg
-    ctx.beginPath()
-    ctx.arc(px, py, pr, 0, Math.PI * 2)
-    ctx.fill()
-  }
-  ctx.filter = 'blur(1.5px)'
-  ctx.strokeStyle = 'rgba(228, 232, 240, 0.4)'
-  ctx.lineWidth = 1.5
-  tracePath()
-  ctx.stroke()
-  ctx.restore()
-}
-
-/** Paints a fire area (base glow + flickering flame blobs) centered at (x, y). */
-function paintFire(x: number, y: number, R: number, t: number, seed: number) {
-  if (!ctx) return
-  const rand = effectRand(seed)
-  ctx.save()
-  const base = ctx.createRadialGradient(x, y, R * 0.1, x, y, R)
-  base.addColorStop(0, 'rgba(255, 120, 30, 0.28)')
-  base.addColorStop(0.7, 'rgba(220, 70, 20, 0.16)')
-  base.addColorStop(1, 'rgba(180, 40, 10, 0)')
-  ctx.fillStyle = base
-  ctx.beginPath()
-  ctx.arc(x, y, R, 0, Math.PI * 2)
-  ctx.fill()
-  ctx.globalCompositeOperation = 'lighter'
-  const blobs = 12
-  for (let i = 0; i < blobs; i++) {
-    const ang = rand(i + 1) * Math.PI * 2
-    const dist = R * (0.12 + 0.62 * rand(i + 31))
-    const fx = x + Math.cos(ang) * dist
-    const fy = y + Math.sin(ang) * dist
-    const flick = 0.55 + 0.45 * Math.sin(t * 9 + i * 1.7 + seed)
-    const fr = R * (0.16 + 0.13 * flick)
-    const g = ctx.createRadialGradient(fx, fy, 0, fx, fy, fr)
-    g.addColorStop(0, `rgba(255, 235, 130, ${0.5 * flick})`)
-    g.addColorStop(0.45, `rgba(255, 140, 40, ${0.38 * flick})`)
-    g.addColorStop(1, 'rgba(200, 50, 10, 0)')
-    ctx.fillStyle = g
-    ctx.beginPath()
-    ctx.arc(fx, fy, fr, 0, Math.PI * 2)
-    ctx.fill()
-  }
-  ctx.restore()
-}
-
 /** Effect radius (screen px) of a smoke/fire grenade, for rendering and hit-test. */
 function smokeRadius() {
   return unitsToScreen(144)
@@ -342,9 +215,9 @@ function drawGrenade(
   const k = clamp((t - ev.t) / span, 0, 1)
   ctx.save()
   if (ev.kind === 'smoke') {
-    paintSmoke(x, y, smokeRadius(), t, ev.x * 0.011 + ev.y * 0.015)
+    effects.paintSmoke(ctx, x, y, smokeRadius(), t, ev.x * 0.011 + ev.y * 0.015)
   } else if (ev.kind === 'fire') {
-    paintFire(x, y, fireRadius(), t, ev.x * 0.013 + ev.y * 0.017)
+    effects.paintFire(ctx, x, y, fireRadius(), t, ev.x * 0.013 + ev.y * 0.017)
   } else if (ev.kind === 'he') {
     ctx.globalAlpha = 1 - k
     ctx.strokeStyle = '#ffb020'
@@ -417,30 +290,7 @@ function drawScorch(
   const { x, y } = w2s(ev.x, ev.y)
   // HE blast covers a smaller area than fire
   const R = unitsToScreen(ev.kind === 'he' ? 90 : 150)
-  const seed = ev.x * 0.013 + ev.y * 0.017
-  const rand = (n: number) => {
-    const v = Math.sin(n * 12.9898 + seed * 78.233) * 43758.5453
-    return v - Math.floor(v)
-  }
-  ctx.save()
-  ctx.globalAlpha = 0.5
-  const verts = 30
-  ctx.beginPath()
-  for (let i = 0; i < verts; i++) {
-    const ang = (i / verts) * Math.PI * 2
-    const wob = 0.82 + 0.14 * rand(i + 101)
-    const px = x + Math.cos(ang) * R * wob
-    const py = y + Math.sin(ang) * R * wob
-    if (i === 0) ctx.moveTo(px, py)
-    else ctx.lineTo(px, py)
-  }
-  ctx.closePath()
-  const grad = ctx.createRadialGradient(x, y, R * 0.1, x, y, R)
-  grad.addColorStop(0, 'rgba(16, 11, 8, 0.9)')
-  grad.addColorStop(1, 'rgba(28, 18, 12, 0.4)')
-  ctx.fillStyle = grad
-  ctx.fill()
-  ctx.restore()
+  effects.paintScorch(ctx, x, y, R, ev.x * 0.013 + ev.y * 0.017)
 }
 
 const PATH_COLOR: Record<string, string> = {
@@ -1068,53 +918,7 @@ function drawPlayer(p: PlayerState, death: { x: number; y: number } | undefined)
 
 // --- comments -----------------------------------------------------------------
 /** Rounded-rect path helper (starts a fresh path). */
-function roundRect(x: number, y: number, w: number, h: number, r: number) {
-  if (!ctx) return
-  const rr = Math.min(r, w / 2, h / 2)
-  ctx.beginPath()
-  ctx.moveTo(x + rr, y)
-  ctx.arcTo(x + w, y, x + w, y + h, rr)
-  ctx.arcTo(x + w, y + h, x, y + h, rr)
-  ctx.arcTo(x, y + h, x, y, rr)
-  ctx.arcTo(x, y, x + w, y, rr)
-  ctx.closePath()
-}
-
-/** Wraps `text` to at most `maxWidth` px, capping at `maxLines` (ellipsis). */
-function wrapText(text: string, maxWidth: number, maxLines: number): string[] {
-  if (!ctx) return [text]
-  const words = text.split(/\s+/).filter(Boolean)
-  const lines: string[] = []
-  let line = ''
-  for (const w of words) {
-    const test = line ? `${line} ${w}` : w
-    if (ctx.measureText(test).width > maxWidth && line) {
-      lines.push(line)
-      line = w
-      if (lines.length === maxLines) break
-    } else {
-      line = test
-    }
-  }
-  if (line && lines.length < maxLines) lines.push(line)
-  if (lines.join(' ').length < text.replace(/\s+/g, ' ').trim().length && lines.length) {
-    lines[lines.length - 1] = `${lines[lines.length - 1].replace(/\s*\S*$/, '')}…`
-  }
-  return lines
-}
-
 // Cache of Path2D per comment kind, for drawing the kind icon on the bubble.
-const kindIconCache = new Map<string, Path2D[]>()
-function kindIconPaths(kind: CommentKind | undefined): Path2D[] {
-  const meta = commentKindMeta(kind)
-  let p = kindIconCache.get(meta.kind)
-  if (!p) {
-    p = meta.paths.map((d) => new Path2D(d))
-    kindIconCache.set(meta.kind, p)
-  }
-  return p
-}
-
 /**
  * Draws a comment text bubble around an anchor `box`: a small white rounded card
  * with dark text, a soft shadow, the kind icon on the left, and a stem pointing
@@ -1138,7 +942,7 @@ function drawCommentBubble(
   const IGAP = 6
   ctx.save()
   ctx.font = '500 12.5px Inter, sans-serif'
-  const lines = wrapText(text, MAXW, 3)
+  const lines = wrapText(ctx, text, MAXW, 3)
   let textW = 0
   for (const l of lines) textW = Math.max(textW, ctx.measureText(l).width)
   const w = ICON + IGAP + Math.min(MAXW, textW) + PAD * 2
@@ -1197,7 +1001,7 @@ function drawCommentBubble(
   ctx.fillStyle = '#ffffff'
   ctx.fill()
   // card
-  roundRect(best.rx, best.ry, w, h, 8)
+  roundRect(ctx, best.rx, best.ry, w, h, 8)
   ctx.fillStyle = '#ffffff'
   ctx.fill()
   // colored marker (the kind color) on the anchor tip
@@ -1332,11 +1136,11 @@ function drawCoachGrenade(g: CoachGrenade) {
   const { x, y } = w2s(pos.x, pos.y)
   const t = props.currentT
   if (g.kind === 'smoke') {
-    paintSmoke(x, y, smokeRadius(), t, pos.x * 0.011 + pos.y * 0.015)
+    effects.paintSmoke(ctx, x, y, smokeRadius(), t, pos.x * 0.011 + pos.y * 0.015)
     return
   }
   if (g.kind === 'fire') {
-    paintFire(x, y, fireRadius(), t, pos.x * 0.013 + pos.y * 0.017)
+    effects.paintFire(ctx, x, y, fireRadius(), t, pos.x * 0.013 + pos.y * 0.017)
     return
   }
   const r = clamp(playerRadius() * 0.7, 9, 26)
@@ -1374,7 +1178,7 @@ function drawAreaLabel(
   const lineH = 14
   ctx.save()
   ctx.font = '600 12px Inter, sans-serif'
-  const lines = wrapText(text, 200, 2)
+  const lines = wrapText(ctx, text, 200, 2)
   let textW = 0
   for (const l of lines) textW = Math.max(textW, ctx.measureText(l).width)
   const w = ICON + IGAP + textW + PAD * 2
@@ -1386,7 +1190,7 @@ function drawAreaLabel(
   ctx.shadowColor = 'rgba(0, 0, 0, 0.45)'
   ctx.shadowBlur = 6
   ctx.shadowOffsetY = 1
-  roundRect(lx, ly, w, h, 6)
+  roundRect(ctx, lx, ly, w, h, 6)
   ctx.fillStyle = 'rgba(17, 18, 26, 0.92)'
   ctx.fill()
   ctx.shadowColor = 'transparent'
@@ -1422,7 +1226,7 @@ function drawAreaLabel(
 function drawHoverOutline(x: number, y: number, w: number, h: number, radius: number) {
   if (!ctx) return
   ctx.save()
-  roundRect(x - 2, y - 2, w + 4, h + 4, radius)
+  roundRect(ctx, x - 2, y - 2, w + 4, h + 4, radius)
   ctx.strokeStyle = '#a78bfa'
   ctx.lineWidth = 2
   ctx.stroke()
@@ -1451,7 +1255,7 @@ function drawAreaText(rx: number, ry: number, rw: number, rh: number, text: stri
     const fs = (lo + hi) >> 1
     ctx.font = `600 ${fs}px Inter, sans-serif`
     const lineH = Math.round(fs * 1.3)
-    const lines = wrapText(text, maxW, 999)
+    const lines = wrapText(ctx, text, maxW, 999)
     let widest = 0
     for (const l of lines) widest = Math.max(widest, ctx.measureText(l).width)
     if (widest <= maxW && lines.length * lineH <= maxH) {
@@ -1465,7 +1269,7 @@ function drawAreaText(rx: number, ry: number, rw: number, rh: number, text: stri
   // box can't fit even the minimum size).
   ctx.font = `600 ${chosen}px Inter, sans-serif`
   const lineH = Math.round(chosen * 1.3)
-  const lines = wrapText(text, maxW, Math.max(1, Math.floor(maxH / lineH)))
+  const lines = wrapText(ctx, text, maxW, Math.max(1, Math.floor(maxH / lineH)))
   ctx.textAlign = 'center'
   ctx.textBaseline = 'middle'
   ctx.fillStyle = '#ffffff'
@@ -1626,7 +1430,7 @@ function draw() {
     if (atRoundEnd && age < 0) age = 0 // shows the final kill X during the hold
     if (age < 0 || age > KILL_FADE) continue
     const { x, y } = w2s(ev.x, ev.y)
-    drawKill(x, y, 1 - age / KILL_FADE)
+    drawKill(ctx, x, y, 1 - age / KILL_FADE)
   }
   for (const ev of props.round?.events ?? []) {
     if (ev.type !== 'shot') continue
@@ -2491,6 +2295,10 @@ function reset() {
 // Radar source: the active floor (multi-level maps) or the calibration radar.
 const radarSource = () => props.radarSrc ?? props.calibration.radar
 
+watch(() => props.round, () => {
+  effects.clear()
+  draw()
+})
 watch(() => props.players, draw)
 watch(() => props.bombBlink, draw)
 watch(() => props.previewPath, draw)

--- a/apps/app/src/viewer/player/canvasUtils.ts
+++ b/apps/app/src/viewer/player/canvasUtils.ts
@@ -1,0 +1,71 @@
+/**
+ * Small, stateless canvas helpers shared by the 2D map renderer. Every function
+ * takes the target 2D context explicitly so it stays decoupled from the
+ * component's reactive state.
+ */
+
+/** Clamps `v` into the inclusive range [a, b]. */
+export const clamp = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v))
+
+/** Red "X" marking a kill location. */
+export function drawKill(ctx: CanvasRenderingContext2D, x: number, y: number, alpha: number) {
+  const r = 7
+  ctx.save()
+  ctx.globalAlpha = alpha
+  ctx.strokeStyle = '#ff4d5e'
+  ctx.lineWidth = 2
+  ctx.beginPath()
+  ctx.moveTo(x - r, y - r)
+  ctx.lineTo(x + r, y + r)
+  ctx.moveTo(x + r, y - r)
+  ctx.lineTo(x - r, y + r)
+  ctx.stroke()
+  ctx.restore()
+}
+
+/** Traces a rounded rectangle path (does not fill/stroke; caller decides). */
+export function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+) {
+  const rr = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + rr, y)
+  ctx.arcTo(x + w, y, x + w, y + h, rr)
+  ctx.arcTo(x + w, y + h, x, y + h, rr)
+  ctx.arcTo(x, y + h, x, y, rr)
+  ctx.arcTo(x, y, x + w, y, rr)
+  ctx.closePath()
+}
+
+/** Wraps `text` to at most `maxWidth` px, capping at `maxLines` (ellipsis).
+ *  Uses the context's current font for measurement, so set it before calling. */
+export function wrapText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+  maxLines: number,
+): string[] {
+  const words = text.split(/\s+/).filter(Boolean)
+  const lines: string[] = []
+  let line = ''
+  for (const w of words) {
+    const test = line ? `${line} ${w}` : w
+    if (ctx.measureText(test).width > maxWidth && line) {
+      lines.push(line)
+      line = w
+      if (lines.length === maxLines) break
+    } else {
+      line = test
+    }
+  }
+  if (line && lines.length < maxLines) lines.push(line)
+  if (lines.join(' ').length < text.replace(/\s+/g, ' ').trim().length && lines.length) {
+    lines[lines.length - 1] = `${lines[lines.length - 1].replace(/\s*\S*$/, '')}…`
+  }
+  return lines
+}

--- a/apps/app/src/viewer/player/grenadeEffects.ts
+++ b/apps/app/src/viewer/player/grenadeEffects.ts
@@ -1,0 +1,243 @@
+/**
+ * Grenade visual effects (smoke clouds, fire areas, scorch marks) for the 2D map.
+ *
+ * Smoke/fire are the most expensive things the viewer paints: blur filters, many
+ * radial gradients and additive blending. Rebuilding them from scratch every
+ * frame blows the per-frame budget on weak machines the moment a grenade goes
+ * off. So each effect is baked once into an offscreen canvas and just blitted
+ * (drawImage) every frame, regenerating only a few times per second to keep the
+ * subtle wobble/flicker. The blit scales the sprite to the current zoom radius,
+ * so it stays correct without re-rasterizing the gradients.
+ *
+ * `createGrenadeEffects()` owns the per-instance sprite cache; all painters take
+ * the target 2D context plus screen-space coordinates, so this module stays
+ * decoupled from the component's transform/reactive state.
+ */
+
+const clamp = (v: number, a: number, b: number) => Math.max(a, Math.min(b, v))
+
+// Deterministic per-position noise, so an effect's shape is stable across frames.
+function effectRand(seed: number) {
+  return (n: number) => {
+    const v = Math.sin(n * 12.9898 + seed * 78.233) * 43758.5453
+    return v - Math.floor(v)
+  }
+}
+
+const SPRITE_REF_R = 150 // radius (px) the effect is baked at inside the sprite
+const SPRITE_PAD = 1.3 // extra canvas margin so blur/wobble isn't clipped
+const EFFECT_ANIM_FPS = 12 // how often the baked sprite is refreshed for animation
+type EffectSprite = { canvas: HTMLCanvasElement; bucket: number }
+
+export interface GrenadeEffects {
+  /** Paints a smoke cloud body (puffy irregular disc) centered at (x, y). */
+  paintSmoke(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    R: number,
+    t: number,
+    seed: number,
+  ): void
+  /** Paints a fire area (base glow + flickering flame blobs) centered at (x, y). */
+  paintFire(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    R: number,
+    t: number,
+    seed: number,
+  ): void
+  /** Darkened patch left where a molotov burned or an HE detonated. Reuses the
+   *  effect's seeded irregular outline so the mark matches the affected area. */
+  paintScorch(
+    ctx: CanvasRenderingContext2D,
+    x: number,
+    y: number,
+    R: number,
+    seed: number,
+  ): void
+  /** Drops every cached sprite (call when the round changes). */
+  clear(): void
+}
+
+export function createGrenadeEffects(): GrenadeEffects {
+  const cache = new Map<string, EffectSprite>()
+
+  /** Returns the offscreen canvas for an effect, (re)baking it when the
+   *  animation bucket advances. Keyed by kind+seed, so memory stays bounded by
+   *  the number of distinct grenades in the round. */
+  function sprite(kind: 'smoke' | 'fire', seed: number, t: number): HTMLCanvasElement {
+    const bucket = Math.floor(t * EFFECT_ANIM_FPS)
+    const key = `${kind}|${seed.toFixed(4)}`
+    let entry = cache.get(key)
+    if (!entry || entry.bucket !== bucket) {
+      // Safety net: callers clear on round change, but bound it in case of long
+      // sessions so distinct grenades can't grow the map unboundedly.
+      if (!entry && cache.size > 96) cache.clear()
+      const dim = Math.ceil(SPRITE_REF_R * 2 * SPRITE_PAD)
+      const canvas = entry?.canvas ?? document.createElement('canvas')
+      if (canvas.width !== dim) {
+        canvas.width = dim
+        canvas.height = dim
+      }
+      const c = canvas.getContext('2d')
+      if (c) {
+        c.clearRect(0, 0, dim, dim)
+        const mid = dim / 2
+        if (kind === 'smoke') paintSmokeRaw(c, mid, mid, SPRITE_REF_R, t, seed)
+        else paintFireRaw(c, mid, mid, SPRITE_REF_R, t, seed)
+      }
+      entry = { canvas, bucket }
+      cache.set(key, entry)
+    }
+    return entry.canvas
+  }
+
+  /** Blits a cached smoke/fire sprite, centered at (x, y) and scaled so the baked
+   *  reference radius maps to the requested radius R. */
+  function blit(
+    ctx: CanvasRenderingContext2D,
+    kind: 'smoke' | 'fire',
+    x: number,
+    y: number,
+    R: number,
+    t: number,
+    seed: number,
+  ) {
+    const half = R * SPRITE_PAD
+    ctx.drawImage(sprite(kind, seed, t), x - half, y - half, half * 2, half * 2)
+  }
+
+  return {
+    paintSmoke: (ctx, x, y, R, t, seed) => blit(ctx, 'smoke', x, y, R, t, seed),
+    paintFire: (ctx, x, y, R, t, seed) => blit(ctx, 'fire', x, y, R, t, seed),
+    paintScorch,
+    clear: () => cache.clear(),
+  }
+}
+
+// --- Raw effect painters (draw into the offscreen sprite canvas) -------------
+function paintSmokeRaw(
+  c: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  R: number,
+  t: number,
+  seed: number,
+) {
+  const rand = effectRand(seed)
+  const verts = 34
+  const ring: { x: number; y: number }[] = []
+  for (let i = 0; i < verts; i++) {
+    const ang = (i / verts) * Math.PI * 2
+    const wob = 0.86 + 0.12 * rand(i + 7) + 0.03 * Math.sin(t * 1.8 + i * 0.5 + seed)
+    ring.push({ x: x + Math.cos(ang) * R * wob, y: y + Math.sin(ang) * R * wob })
+  }
+  const tracePath = () => {
+    c.beginPath()
+    c.moveTo(ring[0].x, ring[0].y)
+    for (let i = 1; i < ring.length; i++) c.lineTo(ring[i].x, ring[i].y)
+    c.closePath()
+  }
+  c.save()
+  c.filter = `blur(${clamp(R * 0.06, 2, 7)}px)`
+  const grad = c.createRadialGradient(x, y, R * 0.1, x, y, R)
+  grad.addColorStop(0, 'rgba(220, 224, 232, 0.46)')
+  grad.addColorStop(0.7, 'rgba(208, 213, 224, 0.34)')
+  grad.addColorStop(1, 'rgba(206, 211, 222, 0.04)')
+  c.fillStyle = grad
+  tracePath()
+  c.fill()
+  const puffs = 7
+  for (let i = 0; i < puffs; i++) {
+    const ang = rand(i + 50) * Math.PI * 2 + t * 0.12
+    const dist = R * (0.1 + 0.42 * rand(i + 80))
+    const px = x + Math.cos(ang) * dist
+    const py = y + Math.sin(ang) * dist
+    const pr = R * (0.28 + 0.22 * rand(i + 90))
+    const pg = c.createRadialGradient(px, py, 0, px, py, pr)
+    pg.addColorStop(0, 'rgba(230, 234, 242, 0.2)')
+    pg.addColorStop(1, 'rgba(220, 224, 232, 0)')
+    c.fillStyle = pg
+    c.beginPath()
+    c.arc(px, py, pr, 0, Math.PI * 2)
+    c.fill()
+  }
+  c.filter = 'blur(1.5px)'
+  c.strokeStyle = 'rgba(228, 232, 240, 0.4)'
+  c.lineWidth = 1.5
+  tracePath()
+  c.stroke()
+  c.restore()
+}
+
+function paintFireRaw(
+  c: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  R: number,
+  t: number,
+  seed: number,
+) {
+  const rand = effectRand(seed)
+  c.save()
+  const base = c.createRadialGradient(x, y, R * 0.1, x, y, R)
+  base.addColorStop(0, 'rgba(255, 120, 30, 0.28)')
+  base.addColorStop(0.7, 'rgba(220, 70, 20, 0.16)')
+  base.addColorStop(1, 'rgba(180, 40, 10, 0)')
+  c.fillStyle = base
+  c.beginPath()
+  c.arc(x, y, R, 0, Math.PI * 2)
+  c.fill()
+  c.globalCompositeOperation = 'lighter'
+  const blobs = 12
+  for (let i = 0; i < blobs; i++) {
+    const ang = rand(i + 1) * Math.PI * 2
+    const dist = R * (0.12 + 0.62 * rand(i + 31))
+    const fx = x + Math.cos(ang) * dist
+    const fy = y + Math.sin(ang) * dist
+    const flick = 0.55 + 0.45 * Math.sin(t * 9 + i * 1.7 + seed)
+    const fr = R * (0.16 + 0.13 * flick)
+    const g = c.createRadialGradient(fx, fy, 0, fx, fy, fr)
+    g.addColorStop(0, `rgba(255, 235, 130, ${0.5 * flick})`)
+    g.addColorStop(0.45, `rgba(255, 140, 40, ${0.38 * flick})`)
+    g.addColorStop(1, 'rgba(200, 50, 10, 0)')
+    c.fillStyle = g
+    c.beginPath()
+    c.arc(fx, fy, fr, 0, Math.PI * 2)
+    c.fill()
+  }
+  c.restore()
+}
+
+// Scorch marks are cheap (a single seeded path + one gradient) and persist for
+// the rest of the round, so they are painted directly rather than cached.
+function paintScorch(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  R: number,
+  seed: number,
+) {
+  const rand = effectRand(seed)
+  ctx.save()
+  ctx.globalAlpha = 0.5
+  const verts = 30
+  ctx.beginPath()
+  for (let i = 0; i < verts; i++) {
+    const ang = (i / verts) * Math.PI * 2
+    const wob = 0.82 + 0.14 * rand(i + 101)
+    const px = x + Math.cos(ang) * R * wob
+    const py = y + Math.sin(ang) * R * wob
+    if (i === 0) ctx.moveTo(px, py)
+    else ctx.lineTo(px, py)
+  }
+  ctx.closePath()
+  const grad = ctx.createRadialGradient(x, y, R * 0.1, x, y, R)
+  grad.addColorStop(0, 'rgba(16, 11, 8, 0.9)')
+  grad.addColorStop(1, 'rgba(28, 18, 12, 0.4)')
+  ctx.fillStyle = grad
+  ctx.fill()
+  ctx.restore()
+}

--- a/apps/app/src/viewer/player/useViewerAssets.ts
+++ b/apps/app/src/viewer/player/useViewerAssets.ts
@@ -1,0 +1,60 @@
+/**
+ * Image/icon assets drawn on the 2D map: per-team mic indicators, weapon icons
+ * and comment-kind glyphs. Images are preloaded once and a redraw is requested
+ * (`onLoad`) as each finishes, so they appear without waiting for the next tick.
+ *
+ * The radar image stays in the component: it is bound to reactive props and the
+ * mount/resize lifecycle, unlike these static assets.
+ */
+
+import { SIDE_COLOR } from '@/viewer/domain/colors'
+import { WEAPON_LABELS, weaponIconPath } from '@/viewer/domain/weaponIcons'
+import { commentKindMeta } from '@/viewer/comments/commentKinds'
+import type { CommentKind, Side } from '@/viewer/domain/schema'
+
+export interface ViewerAssets {
+  /** Talking indicator, preloaded per team color. */
+  micImgs: Record<Side, HTMLImageElement>
+  /** Weapon icons keyed by weapon label (see WEAPON_LABELS). */
+  weaponImgs: Map<string, HTMLImageElement>
+  /** Cached Path2D glyphs for a comment kind (built lazily on first use). */
+  kindIconPaths(kind: CommentKind | undefined): Path2D[]
+}
+
+export function useViewerAssets(onLoad: () => void): ViewerAssets {
+  function makeMic(color: string) {
+    const svg =
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><path d="M12 19v3"/></svg>`
+    const img = new Image()
+    img.src = `data:image/svg+xml,${encodeURIComponent(svg)}`
+    img.onload = onLoad
+    return img
+  }
+  const micImgs: Record<Side, HTMLImageElement> = {
+    CT: makeMic(SIDE_COLOR.CT),
+    T: makeMic(SIDE_COLOR.T),
+  }
+
+  const weaponImgs = new Map<string, HTMLImageElement>()
+  for (const label of WEAPON_LABELS) {
+    const path = weaponIconPath(label)
+    if (!path) continue
+    const img = new Image()
+    img.src = path
+    img.onload = onLoad
+    weaponImgs.set(label, img)
+  }
+
+  const kindIconCache = new Map<string, Path2D[]>()
+  function kindIconPaths(kind: CommentKind | undefined): Path2D[] {
+    const meta = commentKindMeta(kind)
+    let p = kindIconCache.get(meta.kind)
+    if (!p) {
+      p = meta.paths.map((d) => new Path2D(d))
+      kindIconCache.set(meta.kind, p)
+    }
+    return p
+  }
+
+  return { micImgs, weaponImgs, kindIconPaths }
+}


### PR DESCRIPTION
## Why

Smoke and fire are the most expensive things the 2D map paints: blur filters, many radial gradients and additive (`lighter`) blending, all rebuilt from scratch **every frame**. On weak machines that blows the per-frame budget the moment a grenade goes off, so the replay stutters exactly while a smoke/molotov is active and recovers once it dissipates.

## What

**Offscreen sprite cache.** Each effect is baked once into an offscreen canvas and just blitted (`drawImage`) every frame, regenerating only ~12x/sec to keep the subtle wobble/flicker. The blit scales the sprite to the current zoom radius, so it stays correct without re-rasterizing the gradients.

Per frame with 3 smokes + 2 molotovs active, the cost drops from ~50 `createRadialGradient` + 6 blur passes + additive blending to basically **5 `drawImage`**. The visual is unchanged (animation just steps at ~12fps instead of 60, imperceptible on soft effects).

**File split.** `ViewerMap.vue` had grown past 2.6k lines, so the effect work was a good moment to carve out cohesive modules. These are verbatim moves (functions now take the `ctx` explicitly), no behavior change:

- `grenadeEffects.ts` — the sprite cache + smoke/fire/scorch painters
- `canvasUtils.ts` — `clamp`, `drawKill`, `roundRect`, `wrapText`
- `useViewerAssets.ts` — preloaded mic/weapon/comment-kind icons

`ViewerMap.vue`: 2687 -> 2406 lines.

The map transform (zoom/pan + `w2s`/`s2w`) was intentionally left in the component: its state is mutated across many interaction sites in the pan/zoom hot path, so extracting it is high-churn for little payoff.

## Testing

- `pnpm type-check` passes.
- Manual visual check recommended: open a smoke-heavy (`final-mirage`) and molotov-heavy (`final-inferno`) replay and confirm smoke clouds, fire areas, scorch marks, grenade-path icons and the center countdown all render as before.