### PR TITLE
fix(viewer): exclude paused frames from presence heatmap

### DIFF
--- a/apps/app/src/viewer/analysis/HeatmapView.vue
+++ b/apps/app/src/viewer/analysis/HeatmapView.vue
@@ -73,13 +73,28 @@ const timeRange = ref<number[]>([0, 0])
 function freezeSeconds(round: Round): number {
   return (round.startTick - round.freezeStartTick) / props.replay.demoTickRate
 }
-/** Longest live round time across the match: the slider's upper bound. */
+// Absolute tick ranges of match pauses (tactical timeouts / tech pauses). While
+// paused, every player stands frozen at spawn, so those frames would pile
+// hundreds of samples onto a handful of base spots and dwarf the real positions.
+// They are dropped from the presence heatmap (and from the slider's range below).
+const pauseRanges = computed(() =>
+  (props.replay.pauses ?? []).map((p) => [p.startTick, p.endTick] as const),
+)
+function isPaused(tick: number): boolean {
+  for (const [start, end] of pauseRanges.value) if (tick >= start && tick <= end) return true
+  return false
+}
+/** Longest live round time across the match (excluding pauses): the slider's
+ *  upper bound. The last frame can fall inside a pause, so scan for the latest
+ *  non-paused frame rather than just taking `frames.at(-1)`. */
 const maxRoundTime = computed(() => {
   let max = 0
   for (const round of props.replay.rounds) {
     const fz = freezeSeconds(round)
-    const last = round.frames[round.frames.length - 1]
-    if (last) max = Math.max(max, last.t - fz)
+    for (const f of round.frames) {
+      if (isPaused(f.tick)) continue
+      max = Math.max(max, f.t - fz)
+    }
   }
   return Math.ceil(max)
 })
@@ -209,8 +224,10 @@ const rawPoints = computed<Pt[]>(() => {
       // Presence: every sample of every player. High volume, but binning is O(n).
       // Skip freeze-time frames: players sit still in spawn during the buy period,
       // which otherwise makes the CT/T bases dwarf every real position on the map.
+      // Same reasoning for pauses (timeouts): everyone is frozen at spawn.
       for (const f of round.frames) {
         if (f.tick < round.startTick) continue
+        if (isPaused(f.tick)) continue
         for (const p of f.players) {
           if (!p.alive) continue
           out.push({ x: p.x, y: p.y, z: p.z, side: p.side, steamId: p.steamId, t: Math.max(0, f.t - fz) })


### PR DESCRIPTION
## Problem

On the **Presence** heatmap, narrowing the time window to the late part of the round (e.g. "from 87s") could light up huge blobs over the CT/T bases, far bigger than any real position on the map.

## Cause

It was a **tactical timeout**, not an AFK player. During a match pause every player stands frozen at spawn. Those frozen frames land in the tail of the round with a high "live" time, so a late-window selection captures ~hundreds of samples stacked on a handful of spawn spots.

Reproduced with a real demo (de_ancient, a ~94.5s T timeout in round 10): the 9 players each had a **0×0 bounding box** across all post-87s samples (perfectly stationary), one blob per spawn slot.

## Fix

We already parse pause intervals into `replay.pauses` (absolute ticks). This drops frames that fall inside a pause:

- **Presence**: skip paused frames (same reasoning already applied to freeze-time frames).
- **Time slider upper bound**: scan for the latest non-paused frame instead of `frames.at(-1)`, so the slider no longer extends into the dead paused tail. On the test demo the max drops from 140.2s to 129.6s (the new max being a real long round with players actually moving).

Kills/deaths need no change: nobody dies while frozen.

## Notes

Genuine AFK/disconnect *without* a pause is a different case and not handled here, to avoid suppressing legitimate angle holds (presence is time-weighted on purpose). Can follow up with a stationary-dwell cap if we want to cover that too.

## Test plan

- [x] `pnpm type-check`
- [ ] Open the de_ancient demo, Heatmaps > Presence, all rounds/teams, window from ~87s: base blobs gone.