### PR TITLE
fix(viewer): handle Gamers Club two-round knife opener

### DIFF
--- a/apps/app/src/viewer/analysis/RoundStrip.vue
+++ b/apps/app/src/viewer/analysis/RoundStrip.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import type { Round, Side } from '@/viewer/domain/schema'
 import { SIDE_COLOR } from '@/viewer/domain/colors'
-import { isKnifeRound } from '@/viewer/analysis/utilityStats'
+import { roundDisplayLabels } from '@/viewer/analysis/utilityStats'
 import UiIcon from '@/ui/UiIcon.vue'
 import { useI18n } from '@/i18n'
 
@@ -26,14 +26,8 @@ const props = defineProps<{
 
 const model = defineModel<number | 'all'>({ required: true })
 
-const hasKnifeRound = computed(() => {
-  const r0 = props.rounds[0]
-  return r0 ? isKnifeRound(r0) : false
-})
-/** Label per round (knife becomes "0" and shifts the rest), like the player. */
-const roundLabels = computed(() =>
-  props.rounds.map((r, i) => String(hasKnifeRound.value ? i : r.number)),
-)
+/** Label per round (pre-game rounds become "0" and shift the rest), like the player. */
+const roundLabels = computed(() => roundDisplayLabels(props.rounds))
 
 /**
  * Round indices where the teams switched sides versus the previous round

--- a/apps/app/src/viewer/analysis/roundEconomy.ts
+++ b/apps/app/src/viewer/analysis/roundEconomy.ts
@@ -14,6 +14,7 @@
  * swaps, so a team's rounds can be grouped even though its side (CT/T) flips.
  */
 import type { Round, Side } from '@/viewer/domain/schema'
+import { preGameRoundCount } from '@/viewer/analysis/utilityStats'
 
 export type BuyType = 'pistol' | 'eco' | 'semi' | 'force-buy' | 'full'
 
@@ -70,16 +71,6 @@ export interface MatchEconomy {
   teams: [TeamEconomy, TeamEconomy]
   /** Counted rounds (knife round excluded), for the per-round charts. */
   roundCount: number
-}
-
-/**
- * Knife round (FACEIT/scrims open with one to pick sides): the first round with
- * nothing but knives across all samples. It does not count, so it is excluded.
- */
-function hasKnifeRound(rounds: Round[]): boolean {
-  const r0 = rounds[0]
-  if (!r0) return false
-  return r0.frames.every((f) => f.players.every((p) => p.weapon === 'Faca' || p.weapon === ''))
 }
 
 /**
@@ -221,13 +212,13 @@ function classifyBuy(
  * tick rate (defaults to 64), used to find the 7s post-freeze sample.
  */
 export function buildMatchEconomy(rounds: Round[], demoTickRate = 64): MatchEconomy {
-  const knife = hasKnifeRound(rounds)
+  const preGame = preGameRoundCount(rounds)
   const swaps = sideSwaps(rounds)
 
   // Pistol rounds: the first round of each regulation half (round 1 and the
   // first after the halftime swap). Overtime half-starts are NOT pistols (CSDM
   // gates on `OvertimeCount == 0`), so only the first two half-starts count.
-  const firstReal = knife ? 1 : 0
+  const firstReal = preGame
   const halfStarts = [...new Set<number>([firstReal, ...swaps])].sort((a, b) => a - b)
   const pistolIndices = new Set(halfStarts.slice(0, 2))
 
@@ -237,7 +228,7 @@ export function buildMatchEconomy(rounds: Round[], demoTickRate = 64): MatchEcon
 
   rounds.forEach((r, i) => {
     if (swaps.has(i)) swapsSoFar++
-    if (knife && i === 0) return // knife round does not count
+    if (i < preGame) return // pre-game rounds (knife / frameless) do not count
 
     // Which stable team is on CT this round (flips with each swap).
     const ctTeam = swapsSoFar % 2 === 0 ? team0 : team1
@@ -248,7 +239,7 @@ export function buildMatchEconomy(rounds: Round[], demoTickRate = 64): MatchEcon
     const frame = econFrame(r, demoTickRate)
     const pistol = pistolIndices.has(i)
     const prevWinner = i > 0 ? rounds[i - 1].winner : null
-    const roundNumber = knife ? i : r.number
+    const roundNumber = preGame > 0 ? i - preGame + 1 : r.number
 
     const ctAgg = aggregate(frame, 'CT')
     const tAgg = aggregate(frame, 'T')

--- a/apps/app/src/viewer/analysis/utilityStats.ts
+++ b/apps/app/src/viewer/analysis/utilityStats.ts
@@ -59,6 +59,42 @@ export function isKnifeRound(round: Round): boolean {
 }
 
 /**
+ * A pre-game round that precedes the real match and does not count on the
+ * scoreboard: the knife round (knife-only frames) or a frameless "result" round
+ * some platforms emit alongside it. FACEIT opens with a single knife round;
+ * Gamers Club emits two (a 0-frame result round + the knife frames), so the
+ * opener cannot be assumed to be a single round.
+ */
+export function isPreGameRound(round: Round): boolean {
+  return round.frames.length === 0 || isKnifeRound(round)
+}
+
+/**
+ * Count of leading pre-game rounds (knife / frameless openers). Only leading
+ * rounds count, so a pathological frameless round mid-match never shifts the
+ * numbering. Returns 0 when every round looks pre-game (nothing real to anchor).
+ */
+export function preGameRoundCount(rounds: Round[]): number {
+  let n = 0
+  while (n < rounds.length && isPreGameRound(rounds[n])) n++
+  return n >= rounds.length ? 0 : n
+}
+
+/**
+ * Display label per round: leading pre-game rounds are "0" (hidden where the UI
+ * hides the knife round); the real match rounds are numbered from 1. Replaces
+ * the old "knife at index 0 only" assumption, which mis-numbered Gamers Club
+ * demos (two opener rounds). With no pre-game round, the parser's `number` is
+ * kept (matchmaking demos, where it is the source of truth).
+ */
+export function roundDisplayLabels(rounds: Round[]): string[] {
+  const preGame = preGameRoundCount(rounds)
+  return rounds.map((r, i) =>
+    i < preGame ? '0' : preGame === 0 ? String(r.number) : String(i - preGame + 1),
+  )
+}
+
+/**
  * The flash that set up a kill: the most recent blind still active on the victim
  * at the moment of death, thrown by someone on the killer's team against an
  * enemy. Returns the flasher (which may be the killer themselves, a self-flash)
@@ -104,7 +140,7 @@ export function flashSetupForKill(
  * fallback for a player absent from that round's frames.
  */
 export function groupTeams(replay: Replay): Team[] {
-  const ref = replay.rounds.find((r) => !isKnifeRound(r)) ?? replay.rounds[0]
+  const ref = replay.rounds.find((r) => !isPreGameRound(r)) ?? replay.rounds[0]
   const ctName = ref?.ctName || ''
   const tName = ref?.tName || ''
   const sides = ref ? roundSides(ref) : new Map<string, Side>()

--- a/apps/app/src/viewer/player/useReplay.ts
+++ b/apps/app/src/viewer/player/useReplay.ts
@@ -1,7 +1,7 @@
 import { computed, onUnmounted, ref, shallowRef } from 'vue'
 import { useLocalStorage } from '@vueuse/core'
 import type { PlayerMeta, PlayerState, Replay, Round, Side } from '@/viewer/domain/schema'
-import { isKnifeRound, roundSides } from '@/viewer/analysis/utilityStats'
+import { preGameRoundCount, roundDisplayLabels, roundSides } from '@/viewer/analysis/utilityStats'
 
 /** Playback speeds offered in the controls. */
 export const SPEEDS = [1, 2, 4, 8] as const
@@ -201,26 +201,21 @@ export function useReplay() {
   )
 
   /**
-   * Knife round: some servers (FACEIT, scrims) open with a knife-only round to
-   * pick sides. It does not count on the scoreboard, so we treat the opener as
-   * round 0 when it is knife-only.
+   * Leading pre-game rounds: the knife round (FACEIT/scrims open with one to
+   * pick sides) plus any frameless "result" round emitted next to it (Gamers
+   * Club). They do not count on the scoreboard, so they are labeled "0" and the
+   * real rounds are numbered from 1 (see `roundDisplayLabels`).
    */
-  const hasKnifeRound = computed(() => {
-    const r0 = replay.value?.rounds[0]
-    return r0 ? isKnifeRound(r0) : false
-  })
+  const preGameCount = computed(() => preGameRoundCount(replay.value?.rounds ?? []))
+  const hasKnifeRound = computed(() => preGameCount.value > 0)
 
-  /** Label shown per round (knife becomes "0" and shifts the rest). */
-  const roundLabels = computed(() =>
-    (replay.value?.rounds ?? []).map((r, i) =>
-      String(hasKnifeRound.value ? i : r.number),
-    ),
-  )
+  /** Label shown per round (pre-game rounds become "0" and shift the rest). */
+  const roundLabels = computed(() => roundDisplayLabels(replay.value?.rounds ?? []))
 
-  /** Count of "real" rounds (excludes the knife round). */
+  /** Count of "real" rounds (excludes the pre-game rounds). */
   const totalRounds = computed(() => {
     const n = replay.value?.rounds.length ?? 0
-    return hasKnifeRound.value ? n - 1 : n
+    return n - preGameCount.value
   })
 
   const currentRoundLabel = computed(() => roundLabels.value[roundIndex.value] ?? '')


### PR DESCRIPTION
## Problem

On Gamers Club demos the knife round and the whole match were mis-numbered: the real pistol round showed as round 3, the two opener rounds were not collapsed to "0", the economy was shifted by one (and counted the real knife round as played), and the team names/sides could come out inverted.

## Cause

GC emits the knife round as **two** rounds sharing the same freeze/start tick:
1. a **frameless result round** (winner set, reason 9, 0 frames, no events): the knife outcome
2. the round with the actual **knife frames** (winner null)

FACEIT emits a **single** knife round, so the existing pre-game detection assumed one opener at index 0 and broke on GC in three places:

- **Numbering** (`useReplay.ts`, `RoundStrip.vue`): `isKnifeRound(rounds[0])` has a `frames.length > 0` guard, so the 0-frame phantom failed the check and the whole match fell back to `round.number`.
- **Economy** (`roundEconomy.ts`): a local knife check **without** the `frames > 0` guard matched the empty round (`[].every()` is `true`), shifting every round by one and treating the real knife round as played.
- **Teams** (`groupTeams`): it picked the frameless round as its reference, whose `ctName`/`tName` are inverted versus the real match (sides are picked after the knife).

## Fix

Centralize pre-game detection in `utilityStats.ts` and route the four call sites through it (removing three divergent copies):

- `isPreGameRound(round)` = frameless **or** knife-only
- `preGameRoundCount(rounds)` = count of **leading** openers
- `roundDisplayLabels(rounds)` = openers labeled `0`, real rounds numbered from 1

## Verification

Reproduced with a real GC de_mirage demo (two openers):

- numbering: `0 0 1 2 … 24`, total 24; player header reads "Knife round"; economy shows exactly 2 pistols, money curve starting at the pistol, correct team names.
- **FACEIT** (single knife) and **Major/GOTV** (no knife) verified unchanged (`preGameCount` 1 and 0 respectively).
- `type-check` and production `build` pass.

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] GC two-opener demo: rounds, economy, team names
- [x] No-knife (Major) demo: numbering unchanged