### PR TITLE
fix(viewer): hide Gamers Club's frameless knife result round

### DIFF
--- a/apps/app/src/viewer/analysis/RoundStrip.vue
+++ b/apps/app/src/viewer/analysis/RoundStrip.vue
@@ -137,7 +137,8 @@ function onRoundsWheel(e: WheelEvent) {
           </button>
 
           <template v-for="(r, i) in rounds" :key="r.number">
-            <template v-if="!hideKnife || roundLabels[i] !== '0'">
+            <!-- Skip frameless rounds (e.g. Gamers Club's knife "result" round). -->
+            <template v-if="r.frames.length > 0 && (!hideKnife || roundLabels[i] !== '0')">
             <!-- Side-swap marker (halftime / overtime). -->
             <div
               v-if="sideSwaps.has(i)"

--- a/apps/app/src/viewer/player/ViewerControls.vue
+++ b/apps/app/src/viewer/player/ViewerControls.vue
@@ -312,7 +312,10 @@ onMounted(() => centerCurrent('auto'))
           class="flex gap-1.5 overflow-x-auto px-1.5 pb-3 pt-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           @wheel="onRoundsWheel"
         >
+          <!-- Skip frameless rounds (e.g. Gamers Club's knife "result" round):
+               they have no positions, so a bubble for them would seek to nothing. -->
           <template v-for="(r, i) in rounds" :key="r.number">
+            <template v-if="r.frames.length > 0">
             <!-- Side-swap marker (halftime / overtime): drawn before the round
                  where the teams flipped CT<->T. -->
             <div
@@ -365,6 +368,7 @@ onMounted(() => centerCurrent('auto'))
                 class="pointer-events-none absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-white ring-2 ring-ink-900"
               />
             </button>
+            </template>
           </template>
         </div>
       </div>

--- a/apps/app/src/viewer/player/useReplay.ts
+++ b/apps/app/src/viewer/player/useReplay.ts
@@ -234,10 +234,14 @@ export function useReplay() {
   function setReplay(r: Replay) {
     pause()
     replay.value = r
-    roundIndex.value = 0
-    // With skipFreeze on, open past the first round's freeze (the freeze stays
+    // Open on the first round that actually has frames. Some platforms (Gamers
+    // Club) emit a leading frameless "result" round for the knife; starting
+    // there would show an empty map.
+    const startIdx = r.rounds.findIndex((rd) => rd.frames.length > 0)
+    roundIndex.value = startIdx < 0 ? 0 : startIdx
+    // With skipFreeze on, open past that round's freeze (the freeze stays
     // scrubbable to the left); otherwise start at frame 0 so it plays too.
-    const first = r.rounds[0]
+    const first = r.rounds[roundIndex.value]
     frameIndex.value = first && skipFreeze.value ? liveFrame(first) : 0
     frac.value = 0
   }


### PR DESCRIPTION
Follow-up to #50.

## Problem

Gamers Club emits the knife round as two rounds: a frameless "result" round plus the round with the actual knife frames (see #50). After #50 numbered them correctly, the frameless one still rendered as a **second, empty knife bubble** in the round strip, and the player **opened on it**, showing a blank map.

## Fix

- Skip rounds with no frames in the round strip (`RoundStrip.vue`) and the player controls (`ViewerControls.vue`).
- Open the player on the first round that has frames (`useReplay.ts`).

Real rounds always have frames, so FACEIT (single knife) and Major/GOTV (no knife) demos are unaffected: the player still opens on the knife round when there is one, exactly like before.

## Verification

- `pnpm type-check` and production `build` pass.
- Major demo (no knife): round strip unchanged, 0 knife bubbles, 2 pistol bubbles, all rounds render.
- GC structure (one frameless + one knife-frames opener): only the knife-frames bubble shows; the player opens on it instead of the empty round.

## Test plan

- [x] `pnpm type-check` / `pnpm build`
- [x] No-knife (Major) demo: strip unchanged
- [ ] GC demo: a single knife bubble, player opens on the knife round