### PR TITLE
feat: mobile navigation and layout

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -11,10 +11,10 @@
       name="description"
       content="Powerful 2D replay viewer for CS2 demos. Everything is processed locally in your browser: your demos never leave your machine."
     />
-    <link rel="canonical" href="https://cs2.zenojunior.com/" />
+    <link rel="canonical" href="https://cs2d.app/" />
 
     <!-- Open Graph / social sharing. og:image must be an absolute URL. -->
-    <meta property="og:url" content="https://cs2.zenojunior.com/" />
+    <meta property="og:url" content="https://cs2d.app/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="CS Demo Analyzer" />
     <meta property="og:locale" content="pt_BR" />
@@ -23,7 +23,7 @@
       property="og:description"
       content="Powerful 2D replay viewer for CS2 demos. Everything is processed locally in your browser: your demos never leave your machine."
     />
-    <meta property="og:image" content="https://cs2.zenojunior.com/seo.jpg" />
+    <meta property="og:image" content="https://cs2d.app/seo.jpg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:type" content="image/jpeg" />
@@ -34,7 +34,7 @@
       name="twitter:description"
       content="Powerful 2D replay viewer for CS2 demos. Everything is processed locally in your browser: your demos never leave your machine."
     />
-    <meta name="twitter:image" content="https://cs2.zenojunior.com/seo.jpg" />
+    <meta name="twitter:image" content="https://cs2d.app/seo.jpg" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -49,7 +49,7 @@
         "@context": "https://schema.org",
         "@type": "WebApplication",
         "name": "CS Demo Analyzer",
-        "url": "https://cs2.zenojunior.com/",
+        "url": "https://cs2d.app/",
         "description": "Powerful 2D replay viewer for CS2 demos. Everything is processed locally in your browser: your demos never leave your machine.",
         "applicationCategory": "GameApplication",
         "operatingSystem": "Web",

--- a/apps/app/public/robots.txt
+++ b/apps/app/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://cs2.zenojunior.com/sitemap.xml
+Sitemap: https://cs2d.app/sitemap.xml

--- a/apps/app/public/sitemap.xml
+++ b/apps/app/public/sitemap.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://cs2.zenojunior.com/</loc>
+    <loc>https://cs2d.app/</loc>
     <lastmod>2026-06-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://cs2.zenojunior.com/cologne-major-2026</loc>
+    <loc>https://cs2d.app/cologne-major-2026</loc>
     <lastmod>2026-06-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://cs2.zenojunior.com/project</loc>
+    <loc>https://cs2d.app/project</loc>
     <lastmod>2026-06-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://cs2.zenojunior.com/privacy</loc>
+    <loc>https://cs2d.app/privacy</loc>
     <lastmod>2026-06-21</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/apps/app/src/seo.ts
+++ b/apps/app/src/seo.ts
@@ -3,7 +3,7 @@ import { useRoute } from 'vue-router'
 import { useI18n } from '@/i18n'
 
 // Canonical production origin; used for <link rel=canonical> and og:url.
-const SITE_URL = 'https://cs2.zenojunior.com'
+const SITE_URL = 'https://cs2d.app'
 const BRAND = 'CS Demo Analyzer'
 
 // Per-route head data keyed by route name. `titleKey` is an i18n key shown

--- a/apps/app/src/shell/AppSidebar.vue
+++ b/apps/app/src/shell/AppSidebar.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useRoute } from 'vue-router'
+import { useMediaQuery } from '@vueuse/core'
 import Cs2Mark from '@/shell/Cs2Mark.vue'
 import UiIcon from '@/ui/UiIcon.vue'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/ui/tooltip'
@@ -9,9 +11,13 @@ import { useI18n } from '@/i18n'
 // Compact, collapsible primary nav (VS Code activity-bar style). The collapse
 // state is shared (useSidebar) so the top-bar button drives it; when collapsed
 // only the icons show and hovering an item reveals its label as a tooltip.
+// On mobile the sidebar is an off-canvas drawer (driven by `mobileOpen`) and
+// always shows full labels, so it's only ever icon-only on desktop.
 const { t } = useI18n()
 const route = useRoute()
-const { collapsed } = useSidebar()
+const { collapsed, mobileOpen } = useSidebar()
+const isDesktop = useMediaQuery('(min-width: 640px)')
+const iconOnly = computed(() => isDesktop.value && collapsed.value)
 
 // Top: the core tool navigation. The analyzer route ('demoviewer') backs both the
 // upload home and the open viewer; the showcase bracket sits alongside them.
@@ -30,7 +36,7 @@ const MINOR_LINKS = [
 
 function itemClass(name: string) {
   return [
-    collapsed.value ? 'justify-center px-0' : 'px-3',
+    iconOnly.value ? 'justify-center px-0' : 'px-3',
     route.name === name
       ? 'bg-ink-800 text-ink-50'
       : 'text-ink-300 hover:bg-ink-800 hover:text-ink-100',
@@ -40,18 +46,18 @@ function itemClass(name: string) {
 
 <template>
   <aside
-    class="flex shrink-0 flex-col border-r border-ink-800/80 bg-ink-950/80 p-2 transition-[width] duration-200"
-    :class="collapsed ? 'w-14' : 'w-52'"
+    class="fixed inset-y-0 left-0 z-40 flex w-52 shrink-0 flex-col border-r border-ink-800/80 bg-ink-950 p-2 transition-transform duration-200 sm:static sm:z-auto sm:translate-x-0 sm:bg-ink-950/80 sm:transition-[width]"
+    :class="[mobileOpen ? 'translate-x-0' : '-translate-x-full', collapsed ? 'sm:w-14' : 'sm:w-52']"
   >
     <!-- Brand: icon always visible, title hidden when collapsed -->
     <RouterLink
       to="/"
       :aria-label="t('shell.home')"
       class="flex h-10 items-center gap-2 rounded-md px-1 text-ink-200 transition-colors hover:bg-ink-800"
-      :class="collapsed ? 'justify-center' : ''"
+      :class="iconOnly ? 'justify-center' : ''"
     >
       <Cs2Mark size="sm" />
-      <span v-if="!collapsed" class="truncate text-sm font-medium">CS Demo Analyzer</span>
+      <span v-if="!iconOnly" class="truncate text-sm font-medium">CS Demo Analyzer</span>
     </RouterLink>
 
     <TooltipProvider>
@@ -66,10 +72,10 @@ function itemClass(name: string) {
               :class="itemClass(item.name)"
             >
               <UiIcon :name="item.icon" class="h-4 w-4 shrink-0" />
-              <span v-if="!collapsed" class="truncate">{{ t(item.label) }}</span>
+              <span v-if="!iconOnly" class="truncate">{{ t(item.label) }}</span>
             </RouterLink>
           </TooltipTrigger>
-          <TooltipContent v-if="collapsed">{{ t(item.label) }}</TooltipContent>
+          <TooltipContent v-if="iconOnly">{{ t(item.label) }}</TooltipContent>
         </Tooltip>
       </nav>
 
@@ -77,10 +83,10 @@ function itemClass(name: string) {
       <nav class="mt-auto">
         <div
           class="flex items-center justify-center"
-          :class="collapsed ? 'gap-2' : 'gap-3 px-3'"
+          :class="iconOnly ? 'gap-2' : 'gap-3 px-3'"
         >
           <template v-for="(item, i) in MINOR_LINKS" :key="item.name">
-            <span v-if="!collapsed && i > 0" class="text-ink-700">·</span>
+            <span v-if="!iconOnly && i > 0" class="text-ink-700">·</span>
             <Tooltip>
               <TooltipTrigger as-child>
                 <RouterLink
@@ -93,11 +99,11 @@ function itemClass(name: string) {
                       : 'text-ink-500 hover:text-ink-300'
                   "
                 >
-                  <UiIcon v-if="collapsed" :name="item.icon" class="h-3.5 w-3.5" />
+                  <UiIcon v-if="iconOnly" :name="item.icon" class="h-3.5 w-3.5" />
                   <span v-else class="text-xs">{{ t(item.label) }}</span>
                 </RouterLink>
               </TooltipTrigger>
-              <TooltipContent v-if="collapsed">{{ t(item.label) }}</TooltipContent>
+              <TooltipContent v-if="iconOnly">{{ t(item.label) }}</TooltipContent>
             </Tooltip>
           </template>
         </div>

--- a/apps/app/src/shell/PublicShell.vue
+++ b/apps/app/src/shell/PublicShell.vue
@@ -95,7 +95,7 @@ provide(appFullscreenKey, { isFullscreen, toggle })
         </button>
 
         <!-- End: extension dialog + GitHub link + language menu -->
-        <div class="ml-auto flex items-center gap-2">
+        <div class="order-3 ml-auto flex items-center gap-2 sm:order-none">
           <ExtensionDialog v-if="showExtension" />
           <a
             :href="GITHUB_URL"
@@ -135,10 +135,13 @@ provide(appFullscreenKey, { isFullscreen, toggle })
           </Menubar>
         </div>
 
-        <!-- Center: tool actions (via Teleport, e.g. the viewer tabs) -->
+        <!-- Center: tool actions (via Teleport, e.g. the viewer tabs). On narrow
+             viewports it flows between the side controls and scrolls sideways
+             (order-2 places it before the right group); from `sm` up it is the
+             absolutely centered bar it has always been. -->
         <div
           id="publicbar-center"
-          class="absolute inset-y-0 left-1/2 flex -translate-x-1/2 items-center"
+          class="order-2 flex min-w-0 flex-1 items-center overflow-x-auto scrollbar-none sm:absolute sm:inset-y-0 sm:left-1/2 sm:order-none sm:flex-none sm:-translate-x-1/2 sm:overflow-visible"
         />
       </header>
 

--- a/apps/app/src/shell/PublicShell.vue
+++ b/apps/app/src/shell/PublicShell.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, provide, ref } from 'vue'
+import { computed, provide, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useFullscreen } from '@vueuse/core'
+import { useFullscreen, useMediaQuery } from '@vueuse/core'
 import { Flag } from '@blade-flags/vue'
 import { circleFlags } from '@blade-flags/core/flags/circle'
 import UiIcon from '@/ui/UiIcon.vue'
@@ -36,11 +36,29 @@ const showExtension = import.meta.env.DEV
 
 const current = computed(() => LOCALES.find((l) => l.code === locale.value) ?? LOCALES[0])
 
-// Primary-sidebar collapse, driven from the start of the top bar.
-const { collapsed, toggle: toggleSidebar } = useSidebar()
+// Primary-sidebar state, driven from the start of the top bar. On desktop the
+// toggle collapses/expands the in-flow sidebar; on mobile it opens/closes the
+// off-canvas drawer overlay.
+const { collapsed, toggle: toggleSidebar, mobileOpen, closeMobile, toggleMobile } = useSidebar()
+const isDesktop = useMediaQuery('(min-width: 640px)')
+
+function onToggleSidebar() {
+  if (isDesktop.value) toggleSidebar()
+  else toggleMobile()
+}
+// Drives the toggle icon: is the sidebar currently shown? (expanded on desktop,
+// drawer open on mobile.)
+const sidebarShown = computed(() => (isDesktop.value ? !collapsed.value : mobileOpen.value))
 
 const route = useRoute()
 const router = useRouter()
+
+// Close the mobile drawer when navigating or once the viewport grows to desktop
+// (where the sidebar is in-flow and the overlay no longer applies).
+watch(() => route.fullPath, () => closeMobile())
+watch(isDesktop, (desktop) => {
+  if (desktop) closeMobile()
+})
 
 // A demo is being viewed when the analyzer route carries an id (history demo) or a
 // `replay` query (external Major replay). In that case we drop the sidebar and swap
@@ -66,6 +84,13 @@ provide(appFullscreenKey, { isFullscreen, toggle })
   <div ref="shellRoot" class="flex h-dvh overflow-hidden bg-ink-950">
     <AppSidebar v-show="!isFullscreen && !inDemo" />
 
+    <!-- Mobile drawer backdrop: taps outside the open sidebar close it. -->
+    <div
+      v-if="mobileOpen"
+      class="fixed inset-0 z-30 bg-black/50 sm:hidden"
+      @click="closeMobile"
+    />
+
     <div class="flex min-w-0 flex-1 flex-col">
       <header
         v-show="!isFullscreen"
@@ -89,9 +114,9 @@ provide(appFullscreenKey, { isFullscreen, toggle })
           :aria-label="t('shell.toggleMenu')"
           :title="t('shell.toggleMenu')"
           class="grid h-8 w-8 shrink-0 cursor-pointer place-items-center rounded-md text-ink-400 transition-colors hover:bg-ink-800 hover:text-ink-100"
-          @click="toggleSidebar"
+          @click="onToggleSidebar"
         >
-          <UiIcon :name="collapsed ? 'panel-left-open' : 'panel-left-close'" class="h-4 w-4" />
+          <UiIcon :name="sidebarShown ? 'panel-left-close' : 'panel-left-open'" class="h-4 w-4" />
         </button>
 
         <!-- End: extension dialog + GitHub link + language menu -->

--- a/apps/app/src/shell/useSidebar.ts
+++ b/apps/app/src/shell/useSidebar.ts
@@ -24,6 +24,23 @@ function toggle() {
   }
 }
 
+// Mobile drawer state. On narrow viewports the sidebar is off-canvas and opens
+// as an overlay on top of the content instead of pushing it. Not persisted:
+// every visit starts closed.
+const mobileOpen = ref(false)
+
+function openMobile() {
+  mobileOpen.value = true
+}
+
+function closeMobile() {
+  mobileOpen.value = false
+}
+
+function toggleMobile() {
+  mobileOpen.value = !mobileOpen.value
+}
+
 export function useSidebar() {
-  return { collapsed, toggle }
+  return { collapsed, toggle, mobileOpen, openMobile, closeMobile, toggleMobile }
 }

--- a/apps/app/src/style.css
+++ b/apps/app/src/style.css
@@ -162,6 +162,15 @@
   .clip-notch {
     clip-path: polygon(0 0, 100% 0, 100% calc(100% - 0.5rem), calc(100% - 0.5rem) 100%, 0 100%);
   }
+
+  /* Horizontal scroll without a visible scrollbar: used by the tab bars, which
+     scroll sideways on narrow/mobile viewports when the labels overflow. */
+  .scrollbar-none {
+    scrollbar-width: none;
+  }
+  .scrollbar-none::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* ============================================================================

--- a/apps/app/src/viewer/DemoAnalyzerView.vue
+++ b/apps/app/src/viewer/DemoAnalyzerView.vue
@@ -449,7 +449,7 @@ function onImportInput(e: Event) {
         <div class="flex items-center gap-0.5 rounded-lg border border-ink-700 bg-ink-900/60 p-0.5">
           <button
             type="button"
-            class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+            class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
             :class="activeTab === 'viewer' ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
             @click="goTab('viewer')"
           >
@@ -457,7 +457,7 @@ function onImportInput(e: Event) {
           </button>
           <button
             type="button"
-            class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+            class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
             :class="activeTab === 'heatmap' ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
             @click="goTab('heatmap')"
           >
@@ -465,7 +465,7 @@ function onImportInput(e: Event) {
           </button>
           <button
             type="button"
-            class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+            class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
             :class="activeTab === 'utilities' ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
             @click="goTab('utilities')"
           >
@@ -473,7 +473,7 @@ function onImportInput(e: Event) {
           </button>
           <button
             type="button"
-            class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+            class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
             :class="activeTab === 'economy' ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
             @click="goTab('economy')"
           >
@@ -481,7 +481,7 @@ function onImportInput(e: Event) {
           </button>
           <button
             type="button"
-            class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+            class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
             :class="activeTab === 'duels' ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
             @click="goTab('duels')"
           >

--- a/apps/app/src/viewer/analysis/DuelsView.vue
+++ b/apps/app/src/viewer/analysis/DuelsView.vue
@@ -32,13 +32,14 @@ const SUBS: Sub[] = ['matrix', 'opening', 'opening-map']
 
 <template>
   <div class="flex h-full w-full flex-col">
-    <!-- Sub-navigation: Matrix / Opening / Opening map -->
-    <div class="flex shrink-0 items-center justify-center gap-0.5 border-b border-ink-800 px-3 py-2">
+    <!-- Sub-navigation: Matrix / Opening / Opening map. Scrolls sideways on
+         narrow viewports instead of overflowing. -->
+    <div class="flex shrink-0 items-center justify-start gap-0.5 overflow-x-auto border-b border-ink-800 px-3 py-2 scrollbar-none sm:justify-center">
       <button
         v-for="s in SUBS"
         :key="s"
         type="button"
-        class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+        class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
         :class="sub === s ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
         @click="emit('update:sub', s)"
       >

--- a/apps/app/src/viewer/analysis/HeatmapView.vue
+++ b/apps/app/src/viewer/analysis/HeatmapView.vue
@@ -304,13 +304,14 @@ const rangeColor = computed(() => {
 
 <template>
   <div class="flex h-full w-full flex-col">
-    <!-- Sub-navigation: Kills / Deaths / Presence -->
-    <div class="flex shrink-0 items-center justify-center gap-0.5 border-b border-ink-800 px-3 py-2">
+    <!-- Sub-navigation: Presence / Kills / Deaths / Grenades. Scrolls sideways
+         on narrow viewports instead of overflowing. -->
+    <div class="flex shrink-0 items-center justify-start gap-0.5 overflow-x-auto border-b border-ink-800 px-3 py-2 scrollbar-none sm:justify-center">
       <button
         v-for="(meta, key) in SOURCE_META"
         :key="key"
         type="button"
-        class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+        class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
         :class="source === key ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
         @click="emit('update:source', key as Source)"
       >

--- a/apps/app/src/viewer/analysis/HeatmapView.vue
+++ b/apps/app/src/viewer/analysis/HeatmapView.vue
@@ -325,8 +325,12 @@ const rangeColor = computed(() => {
     <div v-else class="flex min-h-0 flex-1 flex-col sm:flex-row">
     <!-- Filters panel: full width on top on mobile, fixed side column from sm up. -->
     <aside class="flex max-h-[40vh] w-full shrink-0 flex-col gap-4 overflow-y-auto border-b border-ink-800 bg-ink-900/40 p-4 sm:max-h-none sm:w-64 sm:border-b-0 sm:border-r">
+      <!-- Filters: a compact grid on mobile (Side full width, Team/Player side by
+           side) to save vertical space; a stacked column from sm up, where
+           sm:contents dissolves this wrapper back into the aside's flex column. -->
+      <div class="grid grid-cols-2 gap-2 sm:contents">
       <!-- Side -->
-      <div :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
+      <div class="col-span-2" :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
         <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.side') }}</label>
         <div class="flex overflow-hidden rounded-md border border-ink-700">
           <button
@@ -353,6 +357,7 @@ const rangeColor = computed(() => {
       <div :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
         <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.player') }}</label>
         <UiSelect v-model="playerFilter" :options="playerOptions" class="w-full" />
+      </div>
       </div>
 
       <p v-if="levels" class="text-xs text-ink-600">

--- a/apps/app/src/viewer/analysis/HeatmapView.vue
+++ b/apps/app/src/viewer/analysis/HeatmapView.vue
@@ -322,9 +322,9 @@ const rangeColor = computed(() => {
     <!-- Grenade detonation heatmap: brings its own filters and plots. -->
     <UtilityHeatmapView v-if="source === 'grenades'" :replay="replay" class="min-h-0 flex-1" />
 
-    <div v-else class="flex min-h-0 flex-1">
-    <!-- Filters panel -->
-    <aside class="flex w-64 shrink-0 flex-col gap-4 overflow-y-auto border-r border-ink-800 bg-ink-900/40 p-4">
+    <div v-else class="flex min-h-0 flex-1 flex-col sm:flex-row">
+    <!-- Filters panel: full width on top on mobile, fixed side column from sm up. -->
+    <aside class="flex max-h-[40vh] w-full shrink-0 flex-col gap-4 overflow-y-auto border-b border-ink-800 bg-ink-900/40 p-4 sm:max-h-none sm:w-64 sm:border-b-0 sm:border-r">
       <!-- Side -->
       <div :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
         <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.side') }}</label>
@@ -361,7 +361,7 @@ const rangeColor = computed(() => {
     </aside>
 
     <!-- Plots: one per floor (side by side) or a single one -->
-    <div class="relative min-w-0 flex-1">
+    <div class="relative min-h-0 min-w-0 flex-1">
       <div class="flex h-full divide-x divide-ink-800">
         <HeatmapPlot
           v-for="plot in plots"

--- a/apps/app/src/viewer/analysis/OpeningDuelMapView.vue
+++ b/apps/app/src/viewer/analysis/OpeningDuelMapView.vue
@@ -159,9 +159,10 @@ const rows = computed(() =>
 </script>
 
 <template>
-  <div class="flex h-full w-full">
-    <!-- Team filter + opening-duel list -->
-    <aside class="flex w-96 shrink-0 flex-col border-r border-ink-800 bg-ink-900/40">
+  <div class="flex h-full w-full flex-col sm:flex-row">
+    <!-- Team filter + opening-duel list: full width on top on mobile (capped
+         height, the list scrolls), fixed side column from sm up. -->
+    <aside class="flex max-h-[45vh] w-full shrink-0 flex-col border-b border-ink-800 bg-ink-900/40 sm:max-h-none sm:w-96 sm:border-b-0 sm:border-r">
       <div class="border-b border-ink-800 p-3">
         <div class="flex overflow-hidden rounded border border-ink-700 text-xs">
           <button
@@ -215,7 +216,7 @@ const rows = computed(() =>
     </aside>
 
     <!-- Plots: one per floor (side by side) or a single one -->
-    <div class="relative min-w-0 flex-1">
+    <div class="relative min-h-0 min-w-0 flex-1">
       <div class="flex h-full divide-x divide-ink-800">
         <HeatmapPlot
           v-for="plot in plots"

--- a/apps/app/src/viewer/analysis/UtilitiesView.vue
+++ b/apps/app/src/viewer/analysis/UtilitiesView.vue
@@ -35,13 +35,14 @@ const SUBS: Sub[] = ['throws', 'flashes', 'damage']
 
 <template>
   <div class="flex h-full w-full flex-col">
-    <!-- Sub-navigation: Throws / Flashes / Damage -->
-    <div class="flex shrink-0 items-center justify-center gap-0.5 border-b border-ink-800 px-3 py-2">
+    <!-- Sub-navigation: Throws / Flashes / Damage. Scrolls sideways on narrow
+         viewports instead of overflowing. -->
+    <div class="flex shrink-0 items-center justify-start gap-0.5 overflow-x-auto border-b border-ink-800 px-3 py-2 scrollbar-none sm:justify-center">
       <button
         v-for="s in SUBS"
         :key="s"
         type="button"
-        class="cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors"
+        class="shrink-0 cursor-pointer whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-colors"
         :class="sub === s ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:text-ink-100'"
         @click="emit('update:sub', s)"
       >

--- a/apps/app/src/viewer/analysis/UtilityHeatmapView.vue
+++ b/apps/app/src/viewer/analysis/UtilityHeatmapView.vue
@@ -135,9 +135,9 @@ const plots = computed<Plot[]>(() => {
 </script>
 
 <template>
-  <div class="flex h-full w-full">
-    <!-- Filters panel -->
-    <aside class="flex w-64 shrink-0 flex-col gap-4 overflow-y-auto border-r border-ink-800 bg-ink-900/40 p-4">
+  <div class="flex h-full w-full flex-col sm:flex-row">
+    <!-- Filters panel: full width on top on mobile, fixed side column from sm up. -->
+    <aside class="flex max-h-[40vh] w-full shrink-0 flex-col gap-4 overflow-y-auto border-b border-ink-800 bg-ink-900/40 p-4 sm:max-h-none sm:w-64 sm:border-b-0 sm:border-r">
       <!-- Grenade type -->
       <div>
         <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.data') }}</label>
@@ -222,7 +222,7 @@ const plots = computed<Plot[]>(() => {
     </aside>
 
     <!-- Plots: one per floor (side by side) or a single one -->
-    <div class="flex min-w-0 flex-1 divide-x divide-ink-800">
+    <div class="flex min-h-0 min-w-0 flex-1 divide-x divide-ink-800">
       <HeatmapPlot
         v-for="plot in plots"
         :key="plot.key"

--- a/apps/app/src/viewer/analysis/UtilityThrowsView.vue
+++ b/apps/app/src/viewer/analysis/UtilityThrowsView.vue
@@ -233,9 +233,10 @@ function onLeave() {
 </script>
 
 <template>
-  <div class="flex h-full w-full">
-    <!-- Filtros + lista -->
-    <aside class="flex w-72 shrink-0 flex-col border-r border-ink-800 bg-ink-900/40">
+  <div class="flex h-full w-full flex-col sm:flex-row">
+    <!-- Filtros + lista: full width on top on mobile (capped height, the list
+         scrolls), fixed side column from sm up. -->
+    <aside class="flex max-h-[45vh] w-full shrink-0 flex-col border-b border-ink-800 bg-ink-900/40 sm:max-h-none sm:w-72 sm:border-b-0 sm:border-r">
       <!-- Filtros -->
       <div class="space-y-2 border-b border-ink-800 p-3">
         <!-- Tipo -->
@@ -328,7 +329,7 @@ function onLeave() {
     </aside>
 
     <!-- Radar: prévia do arco da granada em foco -->
-    <div class="relative min-w-0 flex-1">
+    <div class="relative min-h-0 min-w-0 flex-1">
       <ViewerMap
         :players="[]"
         :current-t="0"

--- a/apps/app/src/viewer/player/ViewerStage.vue
+++ b/apps/app/src/viewer/player/ViewerStage.vue
@@ -977,10 +977,11 @@ defineExpose({ pause: r.pause, jumpToThrow, roundIndex: r.roundIndex })
       :total-rounds="r.totalRounds.value"
     />
 
-    <!-- CT team: bottom-left corner (hidden in comment mode to make room for the panel) -->
+    <!-- CT team: bottom-left corner (hidden in comment mode to make room for the
+         panel, and hidden on mobile where there's no room for the rosters) -->
     <aside
       v-if="!hudHidden && !commentMode"
-      class="pointer-events-auto absolute bottom-4 left-4 z-10 w-52"
+      class="pointer-events-auto absolute bottom-4 left-4 z-10 hidden w-52 sm:block"
     >
       <ViewerRoster
         :players="r.players.value"
@@ -994,10 +995,11 @@ defineExpose({ pause: r.pause, jumpToThrow, roundIndex: r.roundIndex })
       />
     </aside>
 
-    <!-- T team: bottom-right corner (hidden in comment mode to make room for the panel) -->
+    <!-- T team: bottom-right corner (hidden in comment mode to make room for the
+         panel, and hidden on mobile where there's no room for the rosters) -->
     <aside
       v-if="!hudHidden && !commentMode"
-      class="pointer-events-auto absolute bottom-4 right-4 z-10 w-52"
+      class="pointer-events-auto absolute bottom-4 right-4 z-10 hidden w-52 sm:block"
     >
       <ViewerRoster
         :players="r.players.value"

--- a/apps/extension/entrypoints/app.content.ts
+++ b/apps/extension/entrypoints/app.content.ts
@@ -10,7 +10,7 @@ const EXT = 'cs2dv-extension'
 const APP = 'cs2dv-app'
 
 export default defineContentScript({
-  matches: ['*://cs2.zenojunior.com/*', 'http://localhost/*'],
+  matches: ['*://cs2d.app/*', 'http://localhost/*'],
   main() {
     const matchId = new URLSearchParams(location.hash.slice(1)).get('cs2dv')
     if (!matchId) return

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -13,7 +13,7 @@ import { importArchive } from '@cs2/replay-core/demoArchive'
 import { exportLogs, makeLog } from '../utils/log'
 
 // Where stored replays open for playback (the public 2D viewer).
-const WEB_APP = 'https://cs2.zenojunior.com'
+const WEB_APP = 'https://cs2d.app'
 
 const log = makeLog('background')
 // Grab the full log from the service-worker console with `await cs2dvLogs()`.

--- a/apps/extension/entrypoints/faceit.content/App.vue
+++ b/apps/extension/entrypoints/faceit.content/App.vue
@@ -7,7 +7,7 @@ import Select from '@/components/ui/select/Select.vue'
 import type { ActiveJob, ArchiveMetaRow, StateReply } from '@/utils/protocol'
 import { LOCALES, currentLocale, initLocale, setLocale, t, type LocaleCode } from './i18n'
 
-const WEB_APP = 'https://cs2.zenojunior.com'
+const WEB_APP = 'https://cs2d.app'
 
 // Maps whose top-down 2D radar ships in the extension (public/maps/radars).
 const KNOWN_RADARS = new Set([
@@ -398,7 +398,7 @@ onUnmounted(() => {
             </a>
             <a :href="WEB_APP" target="_blank" rel="noopener" class="group relative hover:text-foreground">
               <Globe class="size-4" />
-              <span class="pointer-events-none absolute bottom-full left-1/2 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-foreground opacity-0 shadow-md transition-opacity group-hover:opacity-100">cs2.zenojunior.com</span>
+              <span class="pointer-events-none absolute bottom-full left-1/2 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded border border-border bg-background px-1.5 py-0.5 text-[10px] text-foreground opacity-0 shadow-md transition-opacity group-hover:opacity-100">cs2d.app</span>
             </a>
           </div>
           <span v-if="version" class="text-[10px] text-muted-foreground">v{{ version }}</span>


### PR DESCRIPTION
## Summary

Makes the app usable on mobile / narrow viewports. The desktop layout is unchanged everywhere (all changes are gated behind the `sm` breakpoint).

## Mobile navigation

- **Main tab bar**: lived in an absolutely-centered slot that overflowed and covered the side controls on narrow screens. It now flows between the side controls and scrolls horizontally on mobile; from `sm` up it is the centered bar as before.
- **Sub-tab bars** (heatmaps, utilities, duels): scroll sideways instead of overflowing (shared `.scrollbar-none` utility).
- **Primary sidebar**: opened as an in-flow push even on mobile. It is now an off-canvas **drawer** that opens over the content with a backdrop (closes on tap-outside, on navigation, and when growing back to desktop). Desktop keeps the collapse/expand push.

## Mobile layout

- **Filter sidebars** (heatmaps, utility throws/heatmap, opening-duel map): stacked side by side with the map, squeezing it to a sliver. Now stacked on top (`flex-col sm:flex-row`); the list-bearing ones cap their height so the map stays visible.
- **Heatmap filters** (Side / Team / Player): took ~half the height stacked; laid out in a compact grid on mobile (Side full width, Team/Player side by side).
- **Corner team rosters** in the viewer: hidden on mobile (they overlapped and covered the map); shown from `sm` up.

## Also

- **Production domain** moved from `cs2.zenojunior.com` to `cs2d.app` (canonical/OG/Twitter/JSON-LD, `seo.ts`, robots, sitemap, and the extension). Author site and GitHub URLs unchanged.

Validated with screenshots at 390px and on desktop.
