### PR TITLE
perf: speed up first paint and shrink initial bundle

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -38,10 +38,21 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- Load the Google Fonts stylesheet without blocking the first paint: it
+         applies once downloaded (media swap), so the inline loader and content
+         paint immediately and the fonts swap in via font-display:swap. -->
     <link
       href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
 
     <!-- Structured data: free, browser-based tool (rich results / discovery). -->
     <script type="application/ld+json">
@@ -62,7 +73,43 @@
     </script>
   </head>
   <body>
-    <div id="app"></div>
+    <!-- Inline app shell: painted straight from the static HTML, before the JS
+         bundle and locale finish loading, so the first visit shows the dark
+         background + a spinner instead of a blank/grey screen. Vue clears #app's
+         contents (loader included) when it mounts. -->
+    <style>
+      #app-loading {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #0a0c12;
+      }
+      #app-loading .spinner {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        border: 3px solid #1f2533;
+        border-top-color: #fdac1a;
+        animation: app-loading-spin 0.8s linear infinite;
+      }
+      @keyframes app-loading-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #app-loading .spinner {
+          animation-duration: 2s;
+        }
+      }
+    </style>
+    <div id="app">
+      <div id="app-loading">
+        <div class="spinner"></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/apps/app/src/main.ts
+++ b/apps/app/src/main.ts
@@ -10,6 +10,10 @@ app.use(router)
 app.use(i18n)
 registerDirectives(app)
 
-// Wait for the detected locale's messages to load before painting, so the app
-// shows the right language instead of flashing the pt fallback.
-i18nReady.then(() => app.mount('#app'))
+// Mount right away (replacing the inline #app loader) instead of waiting on the
+// detected locale, so the UI paints as soon as the bundle is ready. pt is bundled
+// so it renders immediately; a non-pt locale swaps in once i18nReady resolves
+// (covered by the inline loader, no blank screen). Errors are swallowed: a failed
+// locale fetch must not keep the app from mounting.
+i18nReady.catch(() => {})
+app.mount('#app')

--- a/apps/app/src/shell/PublicShell.vue
+++ b/apps/app/src/shell/PublicShell.vue
@@ -3,7 +3,7 @@ import { computed, provide, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useFullscreen, useMediaQuery } from '@vueuse/core'
 import { Flag } from '@blade-flags/vue'
-import { circleFlags } from '@blade-flags/core/flags/circle'
+import { localeFlags } from '@/shell/localeFlags'
 import UiIcon from '@/ui/UiIcon.vue'
 import AppSidebar from '@/shell/AppSidebar.vue'
 import ExtensionDialog from '@/shell/ExtensionDialog.vue'
@@ -136,7 +136,7 @@ provide(appFullscreenKey, { isFullscreen, toggle })
           <Menubar>
             <MenubarMenu>
               <MenubarTrigger :aria-label="t('shell.language')">
-                <Flag :code="current.flag" :flags="circleFlags" class="h-4 w-4 shrink-0" />
+                <Flag :code="current.flag" :flags="localeFlags" class="h-4 w-4 shrink-0" />
                 <span class="font-mono text-[11px] font-medium">{{ current.label }}</span>
                 <UiIcon name="chevron-down" class="h-3 w-3 text-ink-500" />
               </MenubarTrigger>
@@ -147,7 +147,7 @@ provide(appFullscreenKey, { isFullscreen, toggle })
                   :class="locale === l.code ? 'bg-ink-800 text-ink-50' : ''"
                   @select="setLocale(l.code as LocaleCode)"
                 >
-                  <Flag :code="l.flag" :flags="circleFlags" class="h-4 w-4 shrink-0" />
+                  <Flag :code="l.flag" :flags="localeFlags" class="h-4 w-4 shrink-0" />
                   <span class="flex-1 truncate">{{ l.name }}</span>
                   <UiIcon
                     v-if="locale === l.code"

--- a/apps/app/src/shell/localeFlags.ts
+++ b/apps/app/src/shell/localeFlags.ts
@@ -1,0 +1,30 @@
+// Only the circle flags for the locales we actually offer. Importing the full
+// `circleFlags` map from @blade-flags/core/flags/circle pulls ~480KB (every
+// country/language flag) into the main bundle even though we show nine. Naming
+// the individual exports lets the bundler tree-shake the rest away.
+//
+// `<Flag :flags="localeFlags" :code="..." />` resolves `country-${code}`, so the
+// keys must stay in that shape (see resolveFlag in @blade-flags/core).
+import {
+  countryBr,
+  countryUs,
+  countryEs,
+  countryFr,
+  countryDe,
+  countryRu,
+  countryPl,
+  countryTr,
+  countryUa,
+} from '@blade-flags/core/flags/circle'
+
+export const localeFlags: Record<string, string> = {
+  'country-br': countryBr,
+  'country-us': countryUs,
+  'country-es': countryEs,
+  'country-fr': countryFr,
+  'country-de': countryDe,
+  'country-ru': countryRu,
+  'country-pl': countryPl,
+  'country-tr': countryTr,
+  'country-ua': countryUa,
+}

--- a/apps/app/src/viewer/DemoAnalyzerView.vue
+++ b/apps/app/src/viewer/DemoAnalyzerView.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, defineAsyncComponent, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useMediaQuery } from '@vueuse/core'
 import UiIcon from '@/ui/UiIcon.vue'
-import ViewerStage from '@/viewer/player/ViewerStage.vue'
-import HeatmapView from '@/viewer/analysis/HeatmapView.vue'
-import UtilitiesView from '@/viewer/analysis/UtilitiesView.vue'
-import EconomyView from '@/viewer/analysis/EconomyView.vue'
-import DuelsView from '@/viewer/analysis/DuelsView.vue'
-import DemoPreviewLoop from '@/viewer/player/DemoPreviewLoop.vue'
+// The stage, the analysis tabs and the ambient preview are only needed once a
+// demo is open (or, for the preview, on desktop). Load them lazily so the idle
+// landing chunk stays small: the dropzone hero is all the first paint needs.
+import type ViewerStageType from '@/viewer/player/ViewerStage.vue'
+const ViewerStage = defineAsyncComponent(() => import('@/viewer/player/ViewerStage.vue'))
+const HeatmapView = defineAsyncComponent(() => import('@/viewer/analysis/HeatmapView.vue'))
+const UtilitiesView = defineAsyncComponent(() => import('@/viewer/analysis/UtilitiesView.vue'))
+const EconomyView = defineAsyncComponent(() => import('@/viewer/analysis/EconomyView.vue'))
+const DuelsView = defineAsyncComponent(() => import('@/viewer/analysis/DuelsView.vue'))
+const DemoPreviewLoop = defineAsyncComponent(() => import('@/viewer/player/DemoPreviewLoop.vue'))
 import { useDemoParser } from '@/viewer/ingest/useDemoParser'
 import { useRecentDemos } from '@/viewer/ingest/useRecentDemos'
 import { importArchive } from '@/viewer/ingest/demoArchive'
@@ -179,11 +184,15 @@ const PREVIEWS = [
 ]
 const previewIndex = ref(Math.floor(Math.random() * PREVIEWS.length))
 const currentPreview = computed(() => PREVIEWS[previewIndex.value])
+// The ambient preview only shows from `lg` up. Gate it on a media query (not just
+// `hidden lg:block`) so it isn't mounted on mobile, where it would still fetch
+// the preview JSON + radar (~250KB) for something the user never sees.
+const showPreview = useMediaQuery('(min-width: 1024px)')
 function nextPreview() {
   previewIndex.value = (previewIndex.value + 1) % PREVIEWS.length
 }
 
-const stage = ref<InstanceType<typeof ViewerStage> | null>(null)
+const stage = ref<InstanceType<typeof ViewerStageType> | null>(null)
 // Leaving the 2D stage pauses playback (the stage stays mounted via v-show).
 watch(activeTab, (tab) => {
   if (tab !== 'viewer') stage.value?.pause()
@@ -587,7 +596,7 @@ function onImportInput(e: Event) {
     <div v-else class="relative h-full overflow-hidden">
       <!-- Looping preview as ambient background, filling the right half of the screen.
            No box or controls: just illustrates what the tool is about. -->
-      <div class="pointer-events-none absolute inset-y-0 right-0 left-1/2 hidden lg:block">
+      <div v-if="showPreview" class="pointer-events-none absolute inset-y-0 right-0 left-1/2">
         <DemoPreviewLoop
           :key="currentPreview"
           :src="currentPreview"


### PR DESCRIPTION
## Why

First visit showed a blank/grey screen for several seconds before the home appeared. The app is a pure SPA with no static markup, mounts only after the locale loads, and ships an 808KB core bundle. Mobile Lighthouse performance was **72** (FCP 4.0s, LCP 5.0s).

## Changes

- **`index.html`** — paint an inline loader (dark background + spinner) straight from static HTML, so the first frame is no longer a blank screen. Load the Google Fonts stylesheet non-blocking (`media="print"` swap) so the first paint no longer waits on a third-party CSS request.
- **`main.ts`** — mount immediately instead of blocking on the detected locale. `pt` (bundled) renders right away; a non-pt locale swaps in once `i18nReady` resolves, covered by the loader.
- **`localeFlags.ts`** (new) — import only the 9 circle flags we actually use instead of the full `circleFlags` map, which dragged ~480KB of every country/language flag into the main chunk. **Core bundle: 808KB -> 351KB.**
- **`DemoAnalyzerView.vue`** — lazy-load the stage, analysis tabs (heatmap/utilities/economy/duels) and the ambient preview; they're only needed once a demo is open. **Landing route chunk: 282KB -> 20KB.** Gate the desktop-only preview on a media query so mobile no longer fetches its JSON + radar (~250KB) for something it never shows.

## Results

Lighthouse 13, mobile preset, measured local vs local (same throttling) to isolate the change from production network latency:

| Metric | Before | After |
|---|---|---|
| Performance | 84 | **97** |
| FCP | 2.7s | 1.8s |
| LCP | 3.8s | 2.2s |
| TTI | 4.6s | 3.1s |

(Against production `cs2d.app` the baseline was 72; the local baseline is higher because there's no network latency.) Accessibility/Best Practices/SEO were already 96/100/100 and are unchanged.

## Verification

- `pnpm type-check` clean, `pnpm build` clean.
- Desktop + mobile screenshots confirm flags, ambient preview and the dropzone render correctly, with the preview correctly absent on mobile.