### PR TITLE
feat(viewer): release follow/auto-zoom when the user drags the map

### DIFF
--- a/apps/app/src/viewer/player/ViewerMap.vue
+++ b/apps/app/src/viewer/player/ViewerMap.vue
@@ -109,6 +109,8 @@ const emit = defineEmits<{
   moveGrenade: [{ id: string; x: number; y: number }]
   /** A placed grenade was removed (right-clicked) from the board. */
   removeGrenade: [{ id: string }]
+  /** The user dragged the map by hand, so auto zoom / follow should release control. */
+  cancelCamera: []
 }>()
 
 const KILL_FADE = 1.4
@@ -2066,16 +2068,24 @@ function onPointerDown(e: PointerEvent) {
     canvas.value?.setPointerCapture(e.pointerId)
     return
   }
-  // Normal mode: left button pans (disabled in auto zoom / follow).
-  if (!props.autoZoom && !props.followSteamId) {
-    dragging = true
-    lastX = e.clientX
-    lastY = e.clientY
-    canvas.value?.setPointerCapture(e.pointerId)
-  }
+  // Normal mode: left button pans. Auto zoom / follow also start a drag, but the
+  // camera mode is only released once the pointer actually moves (see onPointerMove),
+  // so a plain click on a followed player doesn't drop the camera.
+  dragging = true
+  lastX = e.clientX
+  lastY = e.clientY
+  canvas.value?.setPointerCapture(e.pointerId)
 }
 function onPointerMove(e: PointerEvent) {
   if (dragging) {
+    // A hand drag releases auto zoom / follow once it passes the click threshold,
+    // so the manual pan below isn't fought by the camera loops.
+    if ((props.autoZoom || props.followSteamId) && Math.hypot(e.clientX - downX, e.clientY - downY) > 3) {
+      emit('cancelCamera')
+      lastX = e.clientX
+      lastY = e.clientY
+      return
+    }
     panX += e.clientX - lastX
     panY += e.clientY - lastY
     lastX = e.clientX

--- a/apps/app/src/viewer/player/ViewerStage.vue
+++ b/apps/app/src/viewer/player/ViewerStage.vue
@@ -555,6 +555,11 @@ const followSteamId = ref<string | null>(null)
 function toggleFollow(steamId: string) {
   followSteamId.value = followSteamId.value === steamId ? null : steamId
 }
+// Dragging the map by hand hands control back to the user: drop follow and auto zoom.
+function onCancelCamera() {
+  followSteamId.value = null
+  autoZoom.value = false
+}
 const followName = computed(() =>
   followSteamId.value ? (r.playersById.value.get(followSteamId.value)?.name ?? '?') : '',
 )
@@ -750,6 +755,7 @@ defineExpose({ pause: r.pause, jumpToThrow, roundIndex: r.roundIndex })
       @add-grenade="onAddGrenade"
       @move-grenade="onMoveGrenade"
       @remove-grenade="onRemoveGrenade"
+      @cancel-camera="onCancelCamera"
       @drop-comment="onDropComment"
       @select-comment="onSelectComment"
       :popover-anchor="popoverAnchor"


### PR DESCRIPTION
## What

Dragging the map by hand now cancels the follow and auto-zoom modes.

Previously, manual panning was disabled while following a player or with auto-zoom on, so the user had to toggle the mode off before they could move the map. Now a left-button drag starts in any mode, and once it passes the click threshold (3px) it releases follow / auto-zoom so the camera loops stop fighting the manual pan.

A plain click on a followed player still keeps the camera, since the release only triggers on real movement.

## Changes

- `ViewerMap.vue`: new `cancelCamera` emit; left button starts a drag in any mode; `onPointerMove` emits `cancelCamera` (instead of panning) once a drag in follow/auto-zoom passes the click threshold.
- `ViewerStage.vue`: `onCancelCamera` handler clears `followSteamId` and turns off `autoZoom`.

Thanks to @ClementCariou for the suggestion.