### PR TITLE
fix(calibration): use official altitude split for de_nuke floors

### DIFF
--- a/apps/app/src/viewer/domain/calibration.ts
+++ b/apps/app/src/viewer/domain/calibration.ts
@@ -56,12 +56,12 @@ export const MAP_CALIBRATION: Record<string, MapCalibration> = {
     posY: 2887,
     blastRadius: 2275,
     // Nuke is the classic two-floor case: each floor has its own radar. The Z
-    // cut sits BETWEEN the floors: the main one (site A) is around z ~ -415 and
-    // the basement (site B) around z ~ -767, so we split at -575. Upper floor =
-    // higher Z. (Adjust if a real replay shows floors at a different height.)
+    // cut sits BETWEEN the floors. We use the official altitude split from the
+    // cs2-map-icons radar dump (de_nuke verticalsections: -495). Upper floor =
+    // higher Z.
     levels: [
-      { name: 'Superior', minZ: -575, maxZ: Infinity },
-      { name: 'Inferior', minZ: -Infinity, maxZ: -575, radar: '/maps/de_nuke_lower_radar.png' },
+      { name: 'Superior', minZ: -495, maxZ: Infinity },
+      { name: 'Inferior', minZ: -Infinity, maxZ: -495, radar: '/maps/de_nuke_lower_radar.png' },
     ],
   },
   de_ancient: { radar: '/maps/de_ancient_radar.png', scale: 5.0, posX: -2953, posY: 2164, blastRadius: 2250 },


### PR DESCRIPTION
## What

Fix the floor split altitude for `de_nuke` in `MAP_CALIBRATION`.

The Z cut between Nuke's upper floor (site A) and basement (site B) was
hardcoded at `-575`, an educated guess based on where the two sites
roughly sit. The official `verticalsections` data from the
[cs2-map-icons](https://github.com/MurkyYT/cs2-map-icons) radar dump puts
the split at `-495`. This adopts that value so multi-level heatmap points
land on the correct floor / radar.

Vertigo's split (`11700`) and the `pos_x`/`pos_y`/`scale` values for both
maps already matched the official dump, so no other changes were needed.

## Why

Reported by @MurkyYT (maintainer of cs2-map-icons, the source of the
radars we render) in discussion #57.

## Testing

- `pnpm type-check` passes
- `pnpm build` passes
