### PR TITLE
chore: rebrand to CS2d.app and bump extension to 1.0.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CS Demo Analyzer
+# CS2d.app
 
 ## Workflow rules
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CS Demo Analyzer
+# CS2d.app
 
 The fastest free browser-based 2D replay analyzer for **Counter-Strike 2**
 demos. Drop a `.dem` file and rewatch the match round by round: no install,

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cs2-demo-viewer-extension",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "description": "CS2d.app: open any Faceit CS2 match as a 2D replay in one click, parsed locally and 100% offline.",


### PR DESCRIPTION
## Summary
- Rename the project title from **CS Demo Analyzer** to **CS2d.app** in `CLAUDE.md` and `README.md`.
- Bump the extension version `1.0.4` -> `1.0.5`.

Docs/metadata only, no behavior changes.