### PR TITLE
feat(viewer): fluid replay open with autoplay and audio loading state

### DIFF
--- a/apps/app/src/locales/de.json
+++ b/apps/app/src/locales/de.json
@@ -194,6 +194,7 @@
     "zoomOut": "Verkleinern",
     "zoomReset": "Zentrieren",
     "muteComms": "Comms stummschalten",
+    "loadingComms": "Audio wird geladen…",
     "enableComms": "Comms aktivieren",
     "volumeAria": "Gesamtlautstärke der Comms",
     "balance": "CT / T Balance",

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -194,6 +194,7 @@
     "zoomOut": "Zoom out",
     "zoomReset": "Recenter",
     "muteComms": "Mute comms",
+    "loadingComms": "Loading audio…",
     "enableComms": "Enable comms",
     "volumeAria": "Overall comms volume",
     "balance": "CT / T balance",

--- a/apps/app/src/locales/es.json
+++ b/apps/app/src/locales/es.json
@@ -194,6 +194,7 @@
     "zoomOut": "Alejar",
     "zoomReset": "Centrar",
     "muteComms": "Silenciar comms",
+    "loadingComms": "Cargando audio…",
     "enableComms": "Activar comms",
     "volumeAria": "Volumen general de comms",
     "balance": "Balance CT / T",

--- a/apps/app/src/locales/fr.json
+++ b/apps/app/src/locales/fr.json
@@ -194,6 +194,7 @@
     "zoomOut": "Dézoomer",
     "zoomReset": "Recentrer",
     "muteComms": "Couper les comms",
+    "loadingComms": "Chargement de l’audio…",
     "enableComms": "Activer les comms",
     "volumeAria": "Volume général des comms",
     "balance": "Balance CT / T",

--- a/apps/app/src/locales/pl.json
+++ b/apps/app/src/locales/pl.json
@@ -194,6 +194,7 @@
     "zoomOut": "Oddal",
     "zoomReset": "Wyśrodkuj",
     "muteComms": "Wycisz comms",
+    "loadingComms": "Ładowanie audio…",
     "enableComms": "Włącz comms",
     "volumeAria": "Ogólna głośność comms",
     "balance": "Balans CT / T",

--- a/apps/app/src/locales/pt.json
+++ b/apps/app/src/locales/pt.json
@@ -194,6 +194,7 @@
     "zoomOut": "Afastar",
     "zoomReset": "Centralizar",
     "muteComms": "Mutar comms",
+    "loadingComms": "Carregando áudio…",
     "enableComms": "Ativar comms",
     "volumeAria": "Volume geral das comms",
     "balance": "Balanço CT / T",

--- a/apps/app/src/locales/ru.json
+++ b/apps/app/src/locales/ru.json
@@ -194,6 +194,7 @@
     "zoomOut": "Отдалить",
     "zoomReset": "Центрировать",
     "muteComms": "Заглушить войс",
+    "loadingComms": "Загрузка аудио…",
     "enableComms": "Включить войс",
     "volumeAria": "Общая громкость войса",
     "balance": "Баланс CT / T",

--- a/apps/app/src/locales/tr.json
+++ b/apps/app/src/locales/tr.json
@@ -194,6 +194,7 @@
     "zoomOut": "Uzaklaştır",
     "zoomReset": "Yeniden ortala",
     "muteComms": "comms'u sustur",
+    "loadingComms": "Ses yükleniyor…",
     "enableComms": "comms'u etkinleştir",
     "volumeAria": "Genel comms ses düzeyi",
     "balance": "CT / T dengesi",

--- a/apps/app/src/locales/uk.json
+++ b/apps/app/src/locales/uk.json
@@ -194,6 +194,7 @@
     "zoomOut": "Віддалити",
     "zoomReset": "Центрувати",
     "muteComms": "Вимкнути войс",
+    "loadingComms": "Завантаження аудіо…",
     "enableComms": "Увімкнути войс",
     "volumeAria": "Загальна гучність войсу",
     "balance": "Баланс CT / T",

--- a/apps/app/src/viewer/DemoAnalyzerView.vue
+++ b/apps/app/src/viewer/DemoAnalyzerView.vue
@@ -67,8 +67,13 @@ const currentId = ref<string | null>(null)
 const currentSrc = ref<string | null>(null)
 // `?skipFreeze=1` opens the replay past the freeze time (Major clips set it).
 const skipFreeze = computed(() => route.query.skipFreeze === '1' || route.query.skipFreeze === 'true')
-// `?autoplay=1` starts playback as soon as the replay loads (Major clips set it).
-const autoplay = computed(() => route.query.autoplay === '1' || route.query.autoplay === 'true')
+// Playback starts on open by default for a fluid first experience; an explicit
+// `?autoplay=0` (or `false`) opts out, and `?autoplay=1` is still honored.
+const autoplay = computed(() => {
+  const q = route.query.autoplay
+  if (q === undefined) return true
+  return q === '1' || q === 'true'
+})
 type Tab = 'viewer' | 'heatmap' | 'utilities' | 'economy' | 'duels'
 // The active tab is driven by the URL: `/:id` is the 2D stage, `/:id/heatmaps`
 // the heatmap, `/:id/utilities` the utilities page, `/:id/economy` the economy

--- a/apps/app/src/viewer/player/ViewerControls.vue
+++ b/apps/app/src/viewer/player/ViewerControls.vue
@@ -26,6 +26,8 @@ const props = defineProps<{
   showVoice?: boolean
   /** Comms muted (audio off or volume at zero). */
   muted?: boolean
+  /** Comms audio still decoding for the current round (not yet playable). */
+  voiceLoading?: boolean
   /** Master comms volume (0 to 1). */
   masterVolume?: number
   /** CT<->T balance (-1 = CT only, 0 = both, +1 = T only). */
@@ -419,12 +421,23 @@ onMounted(() => centerCurrent('auto'))
         @mouseleave="volHover = false"
       >
         <button
-          v-tooltip="muted ? t('viewer.enableComms') : t('viewer.muteComms')"
+          v-tooltip="
+            voiceLoading && !muted
+              ? t('viewer.loadingComms')
+              : muted
+                ? t('viewer.enableComms')
+                : t('viewer.muteComms')
+          "
           class="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full transition-colors duration-150 hover:bg-white/10"
           :class="muted ? 'text-ink-500 hover:text-white' : 'text-ink-200 hover:text-white'"
           @click="emit('toggleMute')"
         >
-          <UiIcon :name="muted ? 'volume-x' : 'volume-2'" class="h-4 w-4" />
+          <UiIcon
+            v-if="voiceLoading && !muted"
+            name="loader"
+            class="h-4 w-4 animate-spin"
+          />
+          <UiIcon v-else :name="muted ? 'volume-x' : 'volume-2'" class="h-4 w-4" />
         </button>
 
         <!-- Hover panel: volume (left) and CT/T balance (right). The outer pb-2

--- a/apps/app/src/viewer/player/ViewerStage.vue
+++ b/apps/app/src/viewer/player/ViewerStage.vue
@@ -1077,6 +1077,7 @@ defineExpose({ pause: r.pause, jumpToThrow, roundIndex: r.roundIndex })
           :speed="r.speed.value"
           :show-voice="hasVoice && audio.supported"
           :muted="audio.muted.value"
+          :voice-loading="audio.decoding.value"
           :master-volume="audio.masterVolume.value"
           :balance="audio.balance.value"
           :waveform="audio.roundWaveform.value"

--- a/apps/app/src/viewer/player/useReplay.ts
+++ b/apps/app/src/viewer/player/useReplay.ts
@@ -242,15 +242,20 @@ export function useReplay() {
     pause()
     clip.value = null
     replay.value = r
-    // Open on the first round that actually has frames. Some platforms (Gamers
-    // Club) emit a leading frameless "result" round for the knife; starting
-    // there would show an empty map.
-    const startIdx = r.rounds.findIndex((rd) => rd.frames.length > 0)
+    // Land on the first real round (the pistol), skipping any leading pre-game
+    // knife rounds: their freeze + side-pick is noise for a first view. Some
+    // platforms (Gamers Club) also emit a frameless "result" round for the
+    // knife, so we look for the first round with frames at or after the
+    // pre-game block. Fall back to the first round with frames at all.
+    const pre = preGameRoundCount(r.rounds)
+    let startIdx = r.rounds.findIndex((rd, i) => i >= pre && rd.frames.length > 0)
+    if (startIdx < 0) startIdx = r.rounds.findIndex((rd) => rd.frames.length > 0)
     roundIndex.value = startIdx < 0 ? 0 : startIdx
-    // With skipFreeze on, open past that round's freeze (the freeze stays
-    // scrubbable to the left); otherwise start at frame 0 so it plays too.
+    // Always open past that round's freeze so the first experience is fast: the
+    // freeze stays scrubbable to the left. (The skipFreeze toggle still governs
+    // every round the user navigates to afterwards.)
     const first = r.rounds[roundIndex.value]
-    frameIndex.value = first && skipFreeze.value ? liveFrame(first) : 0
+    frameIndex.value = first ? liveFrame(first) : 0
     frac.value = 0
   }
 

--- a/apps/app/src/viewer/player/useVoicePlayback.ts
+++ b/apps/app/src/viewer/player/useVoicePlayback.ts
@@ -85,6 +85,9 @@ export function useVoicePlayback(opts: VoicePlaybackOptions) {
   const sampleRate = computed(() => voice.value?.sampleRate ?? 48000)
   const tickRate = computed(() => voice.value?.tickRate ?? 64)
 
+  /** True while the current round's voice is being decoded (audio not yet
+   *  playable). Drives a loading indicator on the comms control. */
+  const decoding = ref(false)
   const roundVoices = shallowRef<PlayerVoice[]>([])
   const sources = new Map<string, AudioBufferSourceNode>()
   // Sync anchor: audio position = anchorT + (ctx.now - anchorCtx)*speed.
@@ -232,8 +235,23 @@ export function useVoicePlayback(opts: VoicePlaybackOptions) {
     const token = ++decodeToken
     stopSources()
     roundVoices.value = []
-    if (!supported || !anyAudible() || !r || !voice.value) return
+    if (!supported || !anyAudible() || !r || !voice.value) {
+      decoding.value = false
+      return
+    }
+    decoding.value = true
+    try {
+      await decodeRound(r, token)
+    } finally {
+      // Only clear when this is still the active decode; a newer one owns the flag.
+      if (token === decodeToken) decoding.value = false
+    }
+  }
 
+  /** Decodes one round's packets into per-speaker buffers (the heavy work). */
+  async function decodeRound(r: Round, token: number) {
+    const v = voice.value
+    if (!v) return
     const audio = ensureCtx()
     const tr = tickRate.value
     const sr = sampleRate.value
@@ -246,7 +264,7 @@ export function useVoicePlayback(opts: VoicePlaybackOptions) {
     const totalSamples = Math.ceil(durSec * sr)
 
     const result: PlayerVoice[] = []
-    for (const track of voice.value.tracks) {
+    for (const track of v.tracks) {
       const pkts = track.packets.filter((p) => p.tick >= fs && p.tick <= pe)
       if (!pkts.length) continue
 
@@ -302,7 +320,14 @@ export function useVoicePlayback(opts: VoicePlaybackOptions) {
     }
     if (token !== decodeToken) return
     roundVoices.value = result
-    if (playing.value) resync(true)
+    // Engage playback if the replay is already running. This covers autoplay on
+    // open, where `playing` is set before this composable mounts (so the
+    // `watch(playing)` transition never fires): resume the context (allowed via
+    // the page's sticky activation) and start the sources.
+    if (playing.value) {
+      ctx?.resume().catch(() => {})
+      resync(true)
+    }
   }
 
   // ---------------------------------------------------------- transporte (sync)
@@ -364,7 +389,9 @@ export function useVoicePlayback(opts: VoicePlaybackOptions) {
     if (ctx && playing.value && anyAudible()) resync()
   })
 
-  watch(round, (r) => buildRound(r))
+  // Immediate so the round open at mount is decoded even when playback was
+  // started before this composable existed (autoplay on open).
+  watch(round, (r) => buildRound(r), { immediate: true })
 
   watch(balance, () => applyVolumes())
 
@@ -428,6 +455,7 @@ export function useVoicePlayback(opts: VoicePlaybackOptions) {
     supported,
     enabled,
     muted,
+    decoding,
     balance,
     masterVolume,
     mutedSides,


### PR DESCRIPTION
<img width="596" height="323" alt="image" src="https://github.com/user-attachments/assets/ce7a94b2-d25d-44f3-9657-5d73a3b28a50" />

## Summary
Makes the first moments of a replay fast and frictionless, and fixes comms not playing on open.

- **Skip the knife round + first freeze on open**: a replay now opens on the first real (pistol) round, past its freeze time, instead of landing on a leading pre-game knife round and its buy period. The freeze stays scrubbable to the left.
- **Autoplay by default**: opening a replay starts playback automatically. `?autoplay=0` (or `false`) opts out; `?autoplay=1` keeps working as before.
- **Fix silent comms on the first round**: voice was only (re)decoded/started on a `round` or `playing` transition, both of which already had their value before the voice composable mounted, so autoplay-on-open produced no audio until the user changed round or hit pause/play. The opened round is now decoded immediately on mount, and playback engages if the replay is already running (the page's sticky activation allows resuming the `AudioContext`).
- **Audio loading indicator**: while a round's voice is being decoded, the comms button shows a spinner and a "Loading audio…" tooltip, so it's clear the audio isn't playable yet.

## i18n
New `viewer.loadingComms` key added to all 9 locales.

## Testing
- `pnpm type-check` passes.
- Manual: open a replay with recorded voice straight from the library; it starts on the pistol round, plays automatically, and audio comes in after a brief decode (spinner shown meanwhile).