### PR TITLE
feat(pwa): loading feedback on the update toast's reload button

### DIFF
--- a/apps/app/src/PwaPrompt.vue
+++ b/apps/app/src/PwaPrompt.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useRegisterSW } from 'virtual:pwa-register/vue'
+import UiIcon from '@/ui/UiIcon.vue'
 import { useI18n } from '@/i18n'
 
 /**
@@ -10,6 +12,20 @@ import { useI18n } from '@/i18n'
  */
 const { t } = useI18n()
 const { offlineReady, needRefresh, updateServiceWorker } = useRegisterSW()
+
+const reloading = ref(false)
+
+async function reload() {
+  if (reloading.value) return
+  reloading.value = true
+  try {
+    await updateServiceWorker(true)
+  } catch {
+    // Fallback below still forces a reload.
+  }
+  // Force a reload if controllerchange never fires, so the click is never a no-op.
+  window.setTimeout(() => window.location.reload(), 3000)
+}
 
 function dismiss() {
   offlineReady.value = false
@@ -27,12 +43,15 @@ function dismiss() {
       <span>{{ needRefresh ? t('pwa.updateAvailable') : t('pwa.offlineReady') }}</span>
       <button
         v-if="needRefresh"
-        class="rounded-md bg-[#FDAC1A] px-3 py-1 font-medium text-black transition hover:brightness-110"
-        @click="updateServiceWorker(true)"
+        class="flex items-center gap-1.5 rounded-md bg-[#FDAC1A] px-3 py-1 font-medium text-black transition hover:brightness-110 disabled:cursor-default disabled:opacity-80 disabled:hover:brightness-100"
+        :disabled="reloading"
+        @click="reload"
       >
-        {{ t('pwa.reload') }}
+        <UiIcon v-if="reloading" name="loader" class="h-3.5 w-3.5 animate-spin" />
+        {{ reloading ? t('pwa.reloading') : t('pwa.reload') }}
       </button>
       <button
+        v-if="!reloading"
         class="rounded-md px-2 py-1 text-white/60 transition hover:text-white"
         @click="dismiss"
       >

--- a/apps/app/src/locales/de.json
+++ b/apps/app/src/locales/de.json
@@ -3,6 +3,7 @@
     "offlineReady": "Bereit für die Offline-Nutzung.",
     "updateAvailable": "Eine neue Version ist verfügbar.",
     "reload": "Neu laden",
+    "reloading": "Wird aktualisiert…",
     "dismiss": "Jetzt nicht"
   },
   "shell": {

--- a/apps/app/src/locales/en.json
+++ b/apps/app/src/locales/en.json
@@ -3,6 +3,7 @@
     "offlineReady": "Ready to work offline.",
     "updateAvailable": "A new version is available.",
     "reload": "Reload",
+    "reloading": "Updating…",
     "dismiss": "Not now"
   },
   "shell": {

--- a/apps/app/src/locales/es.json
+++ b/apps/app/src/locales/es.json
@@ -3,6 +3,7 @@
     "offlineReady": "Listo para funcionar sin conexión.",
     "updateAvailable": "Hay una nueva versión disponible.",
     "reload": "Actualizar",
+    "reloading": "Actualizando…",
     "dismiss": "Ahora no"
   },
   "shell": {

--- a/apps/app/src/locales/fr.json
+++ b/apps/app/src/locales/fr.json
@@ -3,6 +3,7 @@
     "offlineReady": "Prêt à fonctionner hors ligne.",
     "updateAvailable": "Une nouvelle version est disponible.",
     "reload": "Recharger",
+    "reloading": "Mise à jour…",
     "dismiss": "Pas maintenant"
   },
   "shell": {

--- a/apps/app/src/locales/pl.json
+++ b/apps/app/src/locales/pl.json
@@ -3,6 +3,7 @@
     "offlineReady": "Gotowe do pracy offline.",
     "updateAvailable": "Dostępna jest nowa wersja.",
     "reload": "Odśwież",
+    "reloading": "Aktualizowanie…",
     "dismiss": "Nie teraz"
   },
   "shell": {

--- a/apps/app/src/locales/pt.json
+++ b/apps/app/src/locales/pt.json
@@ -3,6 +3,7 @@
     "offlineReady": "Pronto para funcionar offline.",
     "updateAvailable": "Nova versão disponível.",
     "reload": "Atualizar",
+    "reloading": "Atualizando…",
     "dismiss": "Agora não"
   },
   "shell": {

--- a/apps/app/src/locales/ru.json
+++ b/apps/app/src/locales/ru.json
@@ -3,6 +3,7 @@
     "offlineReady": "Готово к работе офлайн.",
     "updateAvailable": "Доступна новая версия.",
     "reload": "Обновить",
+    "reloading": "Обновление…",
     "dismiss": "Не сейчас"
   },
   "shell": {

--- a/apps/app/src/locales/tr.json
+++ b/apps/app/src/locales/tr.json
@@ -3,6 +3,7 @@
     "offlineReady": "Çevrimdışı çalışmaya hazır.",
     "updateAvailable": "Yeni bir sürüm mevcut.",
     "reload": "Yeniden yükle",
+    "reloading": "Güncelleniyor…",
     "dismiss": "Şimdi değil"
   },
   "shell": {

--- a/apps/app/src/locales/uk.json
+++ b/apps/app/src/locales/uk.json
@@ -3,6 +3,7 @@
     "offlineReady": "Готово до роботи офлайн.",
     "updateAvailable": "Доступна нова версія.",
     "reload": "Оновити",
+    "reloading": "Оновлення…",
     "dismiss": "Не зараз"
   },
   "shell": {


### PR DESCRIPTION
## Summary
The "A new version is available / Reload" toast gave no feedback on click: between activating the new service worker and the actual reload there was a silent gap, and in some cases the reload never fired at all (the button looked inert).

- Clicking **Reload** now enters a loading state: the button shows a spinner, switches to "Updating…", and is disabled; the "Not now" button is hidden while it works.
- Added a safety net that forces `window.location.reload()` if the `controllerchange`-driven reload never fires, so the click is never a no-op.

## i18n
New `pwa.reloading` key added to all 9 locales.

## Testing
- `pnpm type-check` passes.
- Note: PWA service worker behavior only runs in a production build (`pnpm build` + preview), not in `pnpm dev`.