### PR TITLE
chore: point GitHub repo links to zenojunior/cs2d

### DIFF
--- a/apps/app/src/pages/AboutPage.vue
+++ b/apps/app/src/pages/AboutPage.vue
@@ -7,7 +7,7 @@ import { useI18n } from '@/i18n'
 // translatable lives in i18n; the tech/credits lists are data (names + links).
 const { t } = useI18n()
 
-const GITHUB_URL = 'https://github.com/zenojunior/cs-demo-analyzer'
+const GITHUB_URL = 'https://github.com/zenojunior/cs2d'
 const AUTHOR_NAME = 'Zeno Junior'
 const AUTHOR_URL = 'https://zenojunior.com'
 
@@ -110,7 +110,7 @@ const RELATED: { name: string; url: string; desc: string }[] = [
           class="mt-4 inline-flex items-center gap-1.5 rounded-md border border-ink-700 bg-ink-900/60 px-2.5 py-1.5 text-xs text-ink-200 transition-colors hover:bg-ink-800"
         >
           <UiIcon name="github" class="h-3.5 w-3.5 text-ink-400" />
-          <span class="font-medium">zenojunior/cs-demo-analyzer</span>
+          <span class="font-medium">zenojunior/cs2d</span>
         </a>
       </section>
 

--- a/apps/app/src/shell/PublicShell.vue
+++ b/apps/app/src/shell/PublicShell.vue
@@ -28,7 +28,7 @@ const { t, locale, setLocale, LOCALES } = useI18n()
 // with the active route and locale.
 useSeoHead()
 
-const GITHUB_URL = 'https://github.com/zenojunior/cs-demo-analyzer'
+const GITHUB_URL = 'https://github.com/zenojunior/cs2d'
 
 // The Chrome extension isn't publicly installable yet, so its entry point shows
 // only in development; the production build hides it.

--- a/apps/app/src/viewer/ingest/replaySource.ts
+++ b/apps/app/src/viewer/ingest/replaySource.ts
@@ -17,7 +17,7 @@ import { importArchive } from '@/viewer/ingest/demoArchive'
 import type { Replay, ReplayComment, VoiceData } from '@/viewer/domain/schema'
 
 const RAW_BASE =
-  'https://raw.githubusercontent.com/zenojunior/cs-demo-analyzer/main/replays/'
+  'https://raw.githubusercontent.com/zenojunior/cs2d/main/replays/'
 
 /** Base every relative replay ref is resolved against (dev serves from disk). */
 export const REPLAY_BASE = import.meta.env.DEV ? '/_replays/' : RAW_BASE

--- a/apps/extension/entrypoints/faceit.content/App.vue
+++ b/apps/extension/entrypoints/faceit.content/App.vue
@@ -191,7 +191,7 @@ function chooseLocale(code: LocaleCode) {
 }
 
 // --- footer links -----------------------------------------------------------
-const GITHUB = 'https://github.com/zenojunior/cs-demo-analyzer'
+const GITHUB = 'https://github.com/zenojunior/cs2d'
 const version = chrome.runtime.getManifest?.().version ?? ''
 
 // --- panel position: anchored to the top-right corner -----------------------


### PR DESCRIPTION
## What changes

The repository was renamed from `cs-demo-analyzer` to `cs2d`. This PR updates the links that pointed to our old GitHub repo.

### Changed (`zenojunior/cs-demo-analyzer` → `zenojunior/cs2d`)
- `apps/app/src/viewer/ingest/replaySource.ts` — `RAW_BASE` used to fetch shared replays in production (raw.githubusercontent)
- `apps/extension/entrypoints/faceit.content/App.vue` — GitHub link in the extension footer
- `apps/app/src/shell/PublicShell.vue` — `GITHUB_URL`
- `apps/app/src/pages/AboutPage.vue` — `GITHUB_URL` + displayed text

### Left untouched (intentionally)
- `apps/app/src/viewer/analysis/roundEconomy.ts` — refers to `akiver/cs-demo-analyzer`, a third-party repo (CS Demo Manager).
- `apps/app/src/shell/ExtensionDialog.vue` — Chrome Web Store URL; the extension is identified by its ID, not the slug.
