### PR TITLE
feat(duels): standardize filters, sidebar and timeline kill markers

### DIFF
--- a/apps/app/src/shell/PublicShell.vue
+++ b/apps/app/src/shell/PublicShell.vue
@@ -67,6 +67,16 @@ const inDemo = computed(
   () => route.name === 'demoviewer' && Boolean(route.params.id || route.query.replay),
 )
 
+// Text selection is allowed only on the document-like pages: the About/project
+// page, the Privacy page and the upload home (the analyzer route with no demo
+// loaded). Everywhere else the app behaves like a tool, so selection is off.
+const allowSelect = computed(
+  () =>
+    route.name === 'about' ||
+    route.name === 'privacy' ||
+    (route.name === 'demoviewer' && !route.params.id && !route.query.replay),
+)
+
 // Leaving a demo always lands on a non-demo hub: the Major bracket for external
 // replays, the Library for everything else.
 function exitDemo() {
@@ -81,7 +91,7 @@ provide(appFullscreenKey, { isFullscreen, toggle })
 </script>
 
 <template>
-  <div ref="shellRoot" class="flex h-dvh overflow-hidden bg-ink-950">
+  <div ref="shellRoot" class="flex h-dvh overflow-hidden bg-ink-950" :class="{ 'no-select': !allowSelect }">
     <AppSidebar v-show="!isFullscreen && !inDemo" />
 
     <!-- Mobile drawer backdrop: taps outside the open sidebar close it. -->

--- a/apps/app/src/style.css
+++ b/apps/app/src/style.css
@@ -102,6 +102,22 @@
     color: #fff;
   }
 
+  /* The app is a tool, not a document: text selection is disabled on the
+     analyzer/library/major screens (this class is toggled per route). The
+     document-like pages (About, Privacy, the upload home) keep selection.
+     Form fields and editable comments always stay selectable so typing,
+     copying and editing keep working. */
+  .no-select {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  .no-select input,
+  .no-select textarea,
+  .no-select [contenteditable='true'] {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
   /* Subtle scrollbar in the brand tone */
   ::-webkit-scrollbar {
     width: 10px;

--- a/apps/app/src/viewer/analysis/HeatmapView.vue
+++ b/apps/app/src/viewer/analysis/HeatmapView.vue
@@ -4,6 +4,7 @@ import type { Replay, Round, Side } from '@/viewer/domain/schema'
 import { MAP_CALIBRATION } from '@/viewer/domain/calibration'
 import { SIDE_COLOR } from '@/viewer/domain/colors'
 import HeatmapPlot from '@/viewer/analysis/HeatmapPlot.vue'
+import KillfeedRow from '@/viewer/player/KillfeedRow.vue'
 import UtilityHeatmapView from '@/viewer/analysis/UtilityHeatmapView.vue'
 import type { KillInfo } from '@/viewer/analysis/heatmapTypes'
 import { killWeaponIcon } from '@/viewer/domain/weaponIcons'
@@ -251,16 +252,20 @@ const rawPoints = computed<Pt[]>(() => {
   return out
 })
 
+/** Side/team/player filters (the time window is applied separately). */
+function matchesIdentity(p: Pt): boolean {
+  if (!hasIdentity.value) return true
+  if (sideFilter.value !== 'all' && p.side !== sideFilter.value) return false
+  if (teamFilter.value !== 'all' && (!p.steamId || teamOf.value.get(p.steamId) !== teamFilter.value)) return false
+  if (playerFilter.value !== 'all' && p.steamId !== playerFilter.value) return false
+  return true
+}
+
 /** Points after side/player/time (the level filter happens per plot). */
 const points = computed<Pt[]>(() =>
   rawPoints.value.filter((p) => {
     if (!isFullRange.value && (p.t < timeRange.value[0] || p.t > timeRange.value[1])) return false
-    if (hasIdentity.value) {
-      if (sideFilter.value !== 'all' && p.side !== sideFilter.value) return false
-      if (teamFilter.value !== 'all' && (!p.steamId || teamOf.value.get(p.steamId) !== teamFilter.value)) return false
-      if (playerFilter.value !== 'all' && p.steamId !== playerFilter.value) return false
-    }
-    return true
+    return matchesIdentity(p)
   }),
 )
 
@@ -285,6 +290,16 @@ const openKill = ref<{ roundIndex: number; t: number } | null>(null)
 const hasKillList = computed(() => props.source === 'kills' || props.source === 'deaths')
 /** The filtered engagements, in chronological order, for the side list. */
 const killList = computed(() => (hasKillList.value ? points.value.filter((p) => p.kill) : []))
+/** Kill ticks for the round-time bar, ignoring the time window so every kill is
+ *  visible (only side/team/player filters apply). Colored by the subject's side
+ *  (the killer on the kills page, the victim on the deaths page). */
+const killMarkers = computed(() =>
+  hasKillList.value
+    ? rawPoints.value
+        .filter((p) => p.kill && matchesIdentity(p))
+        .map((p) => ({ value: p.t, color: p.side ? SIDE_COLOR[p.side] : '#cbd5e1' }))
+    : [],
+)
 watch([() => props.source, () => points.value], () => {
   hoverKill.value = null
   openKill.value = null
@@ -393,14 +408,27 @@ const rangeColor = computed(() => {
         </div>
       </div>
 
-      <!-- Team -->
-      <div :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
+      <!-- Team: a segmented group button (Both / started-CT team / started-T team),
+           matching the Side control above and the opening-duel map. -->
+      <div class="col-span-2" :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
         <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.team') }}</label>
-        <UiSelect v-model="teamFilter" :options="teamOptions" class="w-full" />
+        <div class="flex overflow-hidden rounded-md border border-ink-700">
+          <button
+            v-for="opt in teamOptions"
+            :key="opt.value"
+            type="button"
+            class="min-w-0 flex-1 cursor-pointer truncate px-2 py-1.5 text-xs transition-colors"
+            :class="teamFilter === opt.value ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:bg-ink-800'"
+            :title="opt.label"
+            @click="teamFilter = opt.value as Side | 'all'"
+          >
+            {{ opt.label }}
+          </button>
+        </div>
       </div>
 
       <!-- Player -->
-      <div :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
+      <div class="col-span-2" :class="{ 'pointer-events-none opacity-40': !hasIdentity }">
         <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.player') }}</label>
         <UiSelect v-model="playerFilter" :options="playerOptions" class="w-full" />
       </div>
@@ -441,39 +469,25 @@ const rangeColor = computed(() => {
         <li v-for="(p, i) in killList" :key="i">
           <button
             type="button"
-            class="flex w-full cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-left transition-colors hover:bg-ink-800"
+            class="flex w-full cursor-pointer items-center gap-2 overflow-hidden rounded px-2 py-1.5 text-left transition-colors hover:bg-ink-800"
             :class="{ 'bg-ink-800': isActiveKill(p) }"
             @click="openKill = { roundIndex: p.kill!.roundIndex, t: p.kill!.t }"
             @mouseenter="hoverKill = { roundIndex: p.kill!.roundIndex, t: p.kill!.t }"
             @mouseleave="hoverKill = null"
           >
-            <span class="min-w-0 flex-1 truncate text-xs" :style="{ color: p.kill!.attackerColor }">{{
-              p.kill!.attackerName || '—'
-            }}</span>
-            <img
-              v-if="p.kill!.assistedFlash"
-              src="/weapons/flash.svg"
-              alt="flash"
-              class="h-3 w-3 shrink-0 object-contain"
+            <span class="w-7 shrink-0 font-mono text-[11px] text-ink-500">R{{ p.kill!.roundNumber }}</span>
+            <KillfeedRow
+              class="min-w-0 flex-1"
+              truncate-names
+              :attacker-name="p.kill!.attackerName"
+              :attacker-color="p.kill!.attackerColor"
+              :assisted-flash="p.kill!.assistedFlash"
+              :weapon="p.kill!.weapon"
+              :headshot="p.kill!.headshot"
+              :victim-name="p.kill!.victimName"
+              :victim-color="p.kill!.victimColor"
             />
-            <img
-              v-if="p.kill!.weaponIcon"
-              :src="p.kill!.weaponIcon"
-              :alt="p.kill!.weapon"
-              class="h-2.5 w-6 shrink-0 object-contain"
-            />
-            <img
-              v-if="p.kill!.headshot"
-              src="/weapons/headshot.svg"
-              alt="hs"
-              class="h-3 w-3 shrink-0 object-contain"
-            />
-            <span class="min-w-0 flex-1 truncate text-right text-xs" :style="{ color: p.kill!.victimColor }">{{
-              p.kill!.victimName
-            }}</span>
-            <span class="shrink-0 font-mono text-[11px] text-ink-500"
-              >R{{ p.kill!.roundNumber }} · {{ fmtTime(p.t) }}</span
-            >
+            <span class="shrink-0 font-mono text-[11px] text-ink-500">{{ fmtTime(p.t) }}</span>
           </button>
         </li>
       </ul>
@@ -517,7 +531,7 @@ const rangeColor = computed(() => {
             <label class="text-xs font-medium text-ink-300">{{ t('heatmap.time') }}</label>
             <span class="font-mono text-xs text-ink-400">{{ timeRange[0] }}s – {{ timeRange[1] }}s</span>
           </div>
-          <RoundTimeRange v-model="timeRange" :max="maxRoundTime" :color="rangeColor" />
+          <RoundTimeRange v-model="timeRange" :max="maxRoundTime" :color="rangeColor" :markers="killMarkers" />
         </div>
       </div>
     </div>

--- a/apps/app/src/viewer/analysis/OpeningDuelMapView.vue
+++ b/apps/app/src/viewer/analysis/OpeningDuelMapView.vue
@@ -31,6 +31,8 @@ const { t } = useI18n()
  *  '1' = started-T team). Team identity is stable across the side swap, unlike a
  *  raw CT/T filter. */
 const teamFilter = ref<string>('all')
+/** Filter by the side that won the opening ('all' / 'CT' / 'T'). */
+const sideFilter = ref<Side | 'all'>('all')
 /** The engagement whose path is emphasized on the map (hovered list row). */
 const highlight = ref<{ roundIndex: number; t: number } | null>(null)
 /** The engagement whose kill popover (mini-clip) is open, from a clicked row. A
@@ -88,6 +90,7 @@ const points = computed<DuelPoint[]>(() => {
   const out: DuelPoint[] = []
   for (const d of computeOpeningDuels(props.replay)) {
     if (teamFilter.value !== 'all' && teamOf.value.get(d.winnerSteamId) !== teamFilter.value) continue
+    if (sideFilter.value !== 'all' && d.winnerSide !== sideFilter.value) continue
     const round = props.replay.rounds[d.roundIndex]
     const aPos = playerPosAt(round, d.winnerSteamId, d.tick)
     out.push({
@@ -169,27 +172,50 @@ const rows = computed(() =>
     <!-- Team filter + opening-duel list: full width on top on mobile (capped
          height, the list scrolls), fixed side column from sm up. -->
     <aside class="flex max-h-[45vh] w-full shrink-0 flex-col border-b border-ink-800 bg-ink-900/40 sm:max-h-none sm:w-96 sm:border-b-0 sm:border-r">
-      <div class="border-b border-ink-800 p-3">
-        <div class="flex overflow-hidden rounded border border-ink-700 text-xs">
-          <button
-            type="button"
-            class="shrink-0 cursor-pointer px-2.5 py-1 transition-colors"
-            :class="teamFilter === 'all' ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:bg-ink-800'"
-            @click="teamFilter = 'all'"
-          >
-            {{ t('heatmap.both') }}
-          </button>
-          <button
-            v-for="tm in teams"
-            :key="tm.id"
-            type="button"
-            class="min-w-0 flex-1 cursor-pointer truncate border-l border-ink-700 px-2 py-1 transition-colors"
-            :class="teamFilter === String(tm.id) ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:bg-ink-800'"
-            :title="tm.name"
-            @click="teamFilter = String(tm.id)"
-          >
-            {{ tm.name }}
-          </button>
+      <div class="flex flex-col gap-4 border-b border-ink-800 p-4">
+        <!-- Side that won the opening (Both / CT / T), matching the kills/deaths
+             point maps and the heatmap. -->
+        <div>
+          <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.side') }}</label>
+          <div class="flex overflow-hidden rounded-md border border-ink-700">
+            <button
+              v-for="s in (['all', 'CT', 'T'] as const)"
+              :key="s"
+              type="button"
+              class="flex-1 cursor-pointer px-2 py-1.5 text-xs transition-colors"
+              :class="sideFilter === s ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:bg-ink-800'"
+              :style="sideFilter === s && s !== 'all' ? { color: SIDE_COLOR[s] } : undefined"
+              @click="sideFilter = s"
+            >
+              {{ s === 'all' ? t('heatmap.both') : s }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Team that won the opening (stable across the side swap). -->
+        <div>
+          <label class="mb-1.5 block text-xs font-medium text-ink-300">{{ t('heatmap.team') }}</label>
+          <div class="flex overflow-hidden rounded-md border border-ink-700">
+            <button
+              type="button"
+              class="min-w-0 flex-1 cursor-pointer truncate px-2 py-1.5 text-xs transition-colors"
+              :class="teamFilter === 'all' ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:bg-ink-800'"
+              @click="teamFilter = 'all'"
+            >
+              {{ t('heatmap.all') }}
+            </button>
+            <button
+              v-for="tm in teams"
+              :key="tm.id"
+              type="button"
+              class="min-w-0 flex-1 cursor-pointer truncate border-l border-ink-700 px-2 py-1.5 text-xs transition-colors"
+              :class="teamFilter === String(tm.id) ? 'bg-ink-700 text-ink-50' : 'text-ink-300 hover:bg-ink-800'"
+              :title="tm.name"
+              @click="teamFilter = String(tm.id)"
+            >
+              {{ tm.name }}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/apps/app/src/viewer/analysis/RoundTimeRange.vue
+++ b/apps/app/src/viewer/analysis/RoundTimeRange.vue
@@ -13,6 +13,10 @@ const props = defineProps<{
   step?: number
   /** Accent color (any CSS color) for the window fill, edges and handles. */
   color?: string
+  /** Event ticks drawn on the track (e.g. kills), each at `value` on the
+   *  [min, max] scale, in its own color. Purely decorative — they don't affect
+   *  the window or capture pointer events. */
+  markers?: { value: number; color: string }[]
 }>()
 
 const model = defineModel<number[]>({ required: true })
@@ -39,6 +43,10 @@ const lo = computed(() => model.value[0] ?? min.value)
 const hi = computed(() => model.value[1] ?? props.max)
 const loPct = computed(() => ((lo.value - min.value) / span.value) * 100)
 const hiPct = computed(() => ((hi.value - min.value) / span.value) * 100)
+/** A value's position on the track, as a clamped 0–100% offset. */
+function pct(value: number): number {
+  return clamp(((value - min.value) / span.value) * 100, 0, 100)
+}
 
 const track = ref<HTMLElement | null>(null)
 // Active drag: which part was grabbed, plus (for 'move') the pointer's offset
@@ -123,6 +131,15 @@ function trackDown(e: PointerEvent) {
       <div class="absolute inset-y-0 left-0 w-px" :style="edgeStyle" />
       <div class="absolute inset-y-0 right-0 w-px" :style="edgeStyle" />
     </div>
+
+    <!-- Event ticks (e.g. kills): thin lines at their time, in their own color.
+         Non-interactive, so they never get in the way of dragging the window. -->
+    <div
+      v-for="(m, i) in markers ?? []"
+      :key="i"
+      class="pointer-events-none absolute inset-y-1 w-0.5 -translate-x-1/2 rounded-full opacity-80"
+      :style="{ left: pct(m.value) + '%', backgroundColor: m.color }"
+    />
 
     <!-- Edge handles: drag to resize the window. -->
     <div

--- a/apps/app/src/viewer/player/ViewerControls.vue
+++ b/apps/app/src/viewer/player/ViewerControls.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { onClickOutside } from '@vueuse/core'
-import type { Pause, ReplayComment, Round, Side } from '@/viewer/domain/schema'
+import type { Pause, PlayerMeta, ReplayComment, Round, Side } from '@/viewer/domain/schema'
 import UiIcon from '@/ui/UiIcon.vue'
 import UiSwitch from '@/ui/UiSwitch.vue'
 import ViewerTimeline from '@/viewer/player/ViewerTimeline.vue'
@@ -42,6 +42,8 @@ const props = defineProps<{
   advancedOptions?: { key: string; label: string; description?: string; enabled: boolean }[]
   /** User comments anchored to the current round (drives the timeline markers). */
   comments?: ReplayComment[]
+  /** Player metadata by Steam ID, for the kill markers' tooltip names. */
+  playersById?: Map<string, PlayerMeta>
   /** Round indices that have at least one comment (drives the round badge). */
   commentedRounds?: Set<number>
   /** Whether comment mode (drop/edit pins on the map) is active. */
@@ -103,7 +105,7 @@ const postStartT = computed(() => {
 /** Freeze duration (s), for the badge — only when there is a real freeze. */
 const freezeSeconds = computed(() => liveStartT.value)
 
-const markers = computed(() => buildTimelineMarkers(props.round, props.comments))
+const markers = computed(() => buildTimelineMarkers(props.round, props.comments, props.playersById))
 
 /**
  * Round indices where the teams switched sides versus the previous round

--- a/apps/app/src/viewer/player/ViewerStage.vue
+++ b/apps/app/src/viewer/player/ViewerStage.vue
@@ -1096,6 +1096,7 @@ defineExpose({ pause: r.pause, jumpToThrow, roundIndex: r.roundIndex })
           :demo-tick-rate="r.replay.value.demoTickRate"
           :pauses="r.replay.value.pauses ?? []"
           :comments="roundComments"
+          :players-by-id="r.playersById.value"
           :commented-rounds="commentedRounds"
           :comment-mode="commentMode"
           :fullscreen="isFullscreen"

--- a/apps/app/src/viewer/player/timelineMarkers.ts
+++ b/apps/app/src/viewer/player/timelineMarkers.ts
@@ -1,10 +1,12 @@
-import type { ReplayComment, Round } from '@/viewer/domain/schema'
+import type { PlayerMeta, ReplayComment, Round } from '@/viewer/domain/schema'
 import { commentDuration } from '@/viewer/comments/commentAnchor'
+import { roundSides } from '@/viewer/analysis/utilityStats'
+import { SIDE_COLOR } from '@/viewer/domain/colors'
 
 /**
  * Marker placed on the round timeline (an instant in seconds). This is the
- * extension point to enrich the timeline: today it marks the bomb plant; later,
- * first kill, comments, 1vX, etc. Just add `kind`s and push markers in
+ * extension point to enrich the timeline: today it marks the bomb plant, the
+ * kills and comments; later, 1vX, etc. Just add `kind`s and push markers in
  * `buildTimelineMarkers`.
  */
 export interface TimelineMarker {
@@ -13,7 +15,7 @@ export interface TimelineMarker {
   /** Fim do intervalo, em segundos: marcadores com duração (comentários) viram
    *  uma faixa de `t` a `endT`; sem ele, um risco pontual. */
   endT?: number
-  kind: 'plant' | 'firstkill' | 'comment' | 'explode'
+  kind: 'plant' | 'kill' | 'comment' | 'explode'
   /** Cor do risco/faixa na timeline. */
   color: string
   /** Texto do tooltip. */
@@ -21,17 +23,32 @@ export interface TimelineMarker {
 }
 
 /** Derives the markers for a round. Extensible: add new `push` calls here.
- *  `comments` are the user comments anchored to this round (already filtered). */
+ *  `comments` are the user comments anchored to this round (already filtered);
+ *  `playersById` resolves the kill markers' tooltip names. */
 export function buildTimelineMarkers(
   round: Round | null,
   comments?: ReplayComment[],
+  playersById?: Map<string, PlayerMeta>,
 ): TimelineMarker[] {
   if (!round) return []
   const markers: TimelineMarker[] = []
 
-  const firstKill = round.events.find((e) => e.type === 'kill')
-  if (firstKill) {
-    markers.push({ t: firstKill.t, kind: 'firstkill', color: '#ffb020', label: 'First kill' })
+  // One tick per kill, colored by the killer's side (CT/T); neutral when the
+  // death has no attacker (suicide / world). Tooltip shows killer ✖ victim.
+  const sides = roundSides(round)
+  const nameOf = (id: string | null) =>
+    (id && playersById?.get(id)?.name) || id || '?'
+  for (const ev of round.events) {
+    if (ev.type !== 'kill') continue
+    const killerSide = ev.attackerSteamId ? sides.get(ev.attackerSteamId) : null
+    markers.push({
+      t: ev.t,
+      kind: 'kill',
+      color: killerSide ? SIDE_COLOR[killerSide] : '#8a93a6',
+      label: ev.attackerSteamId
+        ? `${nameOf(ev.attackerSteamId)} ✖ ${nameOf(ev.victimSteamId)}`
+        : nameOf(ev.victimSteamId),
+    })
   }
 
   const plant = round.bomb.find((b) => b.state === 'planted')


### PR DESCRIPTION
## Summary

A set of consistency improvements across the Duels pages and the timelines, plus a text-selection tweak for the app.

### Duels: kills/deaths sidebar
- The list rows in `/duels` and `/duels/deaths` now follow the same layout as `/duels/opening-map`: round, then killfeed, then time, reusing the `KillfeedRow` component instead of building attacker/icons/victim inline.

### Duels: standardized filters
- The **Team** filter in `/duels` and `/duels/deaths` changed from a `UiSelect` to a segmented **group button**, matching the Side filter style.
- The **opening map** gained the missing **Side (Both/CT/T)** group button (it filters by the side that won the opening), and its filter panel was reorganized with the same labels and spacing as the kills/deaths filters.

### Timelines: kill markers
- The heatmap round-time bar in `/duels` now shows **kill markers colored by side** (CT/T), ignoring the time window so every kill stays visible. Generic `markers` support was added to `RoundTimeRange`.
- The **2D replay main timeline** now marks **every kill**, colored by the killer's side, with a `killer x victim` tooltip (replacing the single first-kill marker).

### Text selection
- Text selection is now disabled across the app, except on the document-like pages (`/project`, `/privacy`, and the upload home). Form fields and editable comments stay selectable.

## Notes
- `pnpm type-check` passing.
- Worth a visual check: the contrast of the kill ticks over the window fill in the heatmap, and readability when many kills cluster together on the 2D timeline.