### PR TITLE
fix(viewer): start auto-zoom loop when enabled from the start

### DIFF
--- a/apps/app/src/viewer/player/useMapCamera.ts
+++ b/apps/app/src/viewer/player/useMapCamera.ts
@@ -175,10 +175,11 @@ export function useMapCamera(opts: MapCameraOptions) {
   )
 
   /** Kick the auto-zoom loop when framing is set from the start (e.g. an embedded
-   *  clip): unlike the autoZoom toggle, it has no off->on edge for the watch to
-   *  catch. Call once the canvas has been laid out (after the first resize). */
+   *  clip or the home preview): unlike toggling it live, this has no off->on edge
+   *  for the watch to catch. Call once the canvas has been laid out (after the
+   *  first resize). */
   function kickIfFocused() {
-    if ((opts.focusSteamIds()?.length || opts.focusWorld()) && !autoRaf) {
+    if (autoActive() && !autoRaf) {
       autoRaf = requestAnimationFrame(autoStep)
     }
   }


### PR DESCRIPTION
## Problem

`kickIfFocused` — called after the canvas is laid out to start the camera loop when framing is set from the start — only accounted for `focusSteamIds`/`focusWorld`. A `ReplayClip`/`DemoPreviewLoop` mounted with plain `auto-zoom` (no focus) never started the loop: there is no off->on edge for the `watch` to catch either, so the camera sat still framing the whole map.

## Fix

Gate the kick on `autoActive()` instead, which already covers `autoZoom`, `focusSteamIds` and `focusWorld` (respecting the `followSteamId` precedence). Any use with initial `auto-zoom` now works.

## Testing

- `pnpm type-check` passes.
- Verified with a `ReplayClip` mounted with `auto-zoom`: the camera now frames the living players with easing from the start.